### PR TITLE
feat: 2026 modern redesign — graphite+amber palette, hero, bento grid, AI-agent readiness

### DIFF
--- a/.cursor/QUICK_REFERENCE.md
+++ b/.cursor/QUICK_REFERENCE.md
@@ -3,7 +3,9 @@
 ## 🎨 Design System Quick Look
 
 ### Colors (CSS Variables)
-- Accent: `var(--accent-blue)` = `#d4a04f` (warm gold)
+- Accent: `var(--accent)` = `#d97706` light / `#f59e0b` dark (amber)
+- Accent for small text (light mode): `var(--accent-text)` = `#92400e`
+- Text on filled amber: `var(--accent-contrast)` = `#1c1917` (never white)
 - Text Primary: `var(--text-primary)`
 - Text Secondary: `var(--text-secondary)`
 - Background: `var(--primary-bg)`
@@ -76,7 +78,7 @@ document.documentElement.setAttribute('data-lang', lang);
 ```
 
 ## 🚫 Don'ts
-- ❌ Don't use blue/cold colors (use warm gold/sepia)
+- ❌ Don't use blue/cold colors (use warm graphite + amber)
 - ❌ Don't skip heading levels (H1 → H2 → H3)
 - ❌ Don't forget `rel="noopener"` on external links
 - ❌ Don't hardcode colors (use CSS variables)

--- a/.cursorrules
+++ b/.cursorrules
@@ -10,28 +10,45 @@ Personal professional portfolio website for Brahim Bousnguar - Senior E-Commerce
 
 ### Color Palette (CSS Variables)
 **Light Theme (Default):**
-- Primary Background: `#faf8f3` (warm sepia/cream)
-- Secondary Background: `#f5f1e8`
-- Sidebar Background: `#f8f5ed`
-- Accent Color: `#d4a04f` (warm gold/amber)
-- Accent Hover: `#b8894a`
-- Text Primary: `#2d2416` (dark brown)
-- Text Secondary: `#5a4a34`
-- Text Muted: `#8b7a5e`
+- Primary Background: `#faf9f7` (warm off-white)
+- Secondary Background: `#f5f4f2`
+- Sidebar Background: `#f7f6f4`
+- Accent: `--accent: #d97706` (amber)
+- Accent Hover: `--accent-hover: #b45309`
+- Accent Text: `--accent-text: #92400e` (AA-safe amber for small text/links)
+- Accent Contrast: `--accent-contrast: #1c1917` (text on filled amber surfaces)
+- Accent Light: `--accent-light: #fdf0df` (tinted chips/washes)
+- Text Primary: `#1c1917` (warm graphite)
+- Text Secondary: `#44403c`
+- Text Muted: `#78716c` (meta/captions only — borderline 4.5:1)
 - Surface Dark: `#ffffff` (white cards)
-- Surface Light: `#f9f6ed`
-- Border Subtle: `#e8dfc8`
-- Border Medium: `#d4c9b0`
+- Surface Light: `#faf9f7`
+- Border Subtle: `#e7e5e4`
+- Border Medium: `#d6d3d1`
 
 **Dark Theme:**
-- Primary Background: `#1a1510` (dark sepia)
-- Secondary Background: `#2a2318`
-- Text Primary: `#e8dfc8` (light cream)
+- Primary Background: `#121110` (warm near-black)
+- Secondary Background / Cards: `#1c1a18`
+- Accent: `#f59e0b`, Accent Hover: `#fbbf24`, Accent Text: `#f59e0b`
+- Text Primary: `#f5f4f2`
 - Use CSS variable pattern: `var(--variable-name)`
 
+**Additional Tokens:**
+- Motion: `--transition-fast` (150ms), `--transition-base` (250ms), `--transition-slow` (400ms)
+- Radii: `--radius-sm` (6px), `--radius-md` (10px), `--radius-lg` (16px), `--radius-xl` (24px)
+- Glass: `--glass-bg`, `--glass-border` (use with `backdrop-filter: blur()` + `@supports` fallback)
+
+**Accent Usage Rules (WCAG AA — critical):**
+- `#d97706` on white/`#faf9f7` is only ~3.1:1 → NEVER use `--accent` for normal-size
+  text in light mode. Allowed: headings ≥24px (or ≥18.66px bold), icons, borders,
+  decorative elements, backgrounds.
+- Small amber text/links in light mode must use `--accent-text` (#92400e, ~6.4:1).
+- Filled amber buttons/chips use dark text `--accent-contrast` (#1c1917, ~5.4:1).
+  NEVER white text on amber (fails at ~3.1:1).
+
 **Design Philosophy:**
-- Warm, professional sepia/gold palette (NOT blue/cold colors)
-- Elegant, minimalist aesthetic
+- Warm graphite + amber palette — amber is the only accent hue; never blue/cold colors
+- Modern, dynamic, but professional: scroll-reveal motion, glass surfaces, fluid type
 - Professional business consultant feel
 - Avoid bright/neon colors or childish elements
 
@@ -212,14 +229,16 @@ Format: JSON-LD in `<script type="application/ld+json">` blocks
 ```
 /
 ├── index.html (main page)
-├── about.html (about page)
-├── css/
-│   ├── style.css (main styles)
-│   └── about.css (page-specific styles)
-├── img/
-│   ├── profile.jpeg
-│   └── favicon.png
-├── icons/ (social media icons)
+├── about.html / learning.html (redirect stubs → pages/)
+├── pages/
+│   ├── about.html
+│   └── learning.html
+├── assets/
+│   ├── css/ (style.css, about.css, learning.css)
+│   ├── js/ (main.js, learning.js + one-off Python data scripts)
+│   ├── img/ (profile.jpeg, favicon.png)
+│   └── data/ (learning-data.json)
+├── docs/ (CV PDF, SEO-GUIDE.md, TODO.md)
 ├── sitemap.xml
 ├── robots.txt
 └── .cursorrules (this file)
@@ -238,7 +257,7 @@ Format: JSON-LD in `<script type="application/ld+json">` blocks
 ### Favicon
 - Multiple sizes: `favicon.png`, `favicon.ico`
 - Apple touch icon: `180x180` PNG
-- Theme color: `#0066ff` (or adjust to match brand)
+- Theme color: `#faf9f7` (light) / `#121110` (dark) via media-scoped meta tags
 
 ## Link Standards
 
@@ -332,7 +351,7 @@ Before marking any task complete, ensure:
 ## AI Assistant Guidelines
 
 When working on this project:
-1. **Always maintain** the warm sepia/gold color scheme - never use blue/cold colors
+1. **Always maintain** the warm graphite + amber color scheme - amber is the only accent hue; never use blue/cold colors, and respect the Accent Usage Rules (no small amber text in light mode, no white text on amber)
 2. **Preserve** the professional, minimalist aesthetic
 3. **Follow** existing code patterns and structure
 4. **Check** both light and dark themes after changes
@@ -354,7 +373,7 @@ When working on this project:
 
 ---
 
-**Last Updated**: 2025-01-22
+**Last Updated**: 2026-06-10
 **Project Type**: Professional Portfolio Website
 **Primary Technologies**: HTML5, CSS3, Vanilla JavaScript
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,15 +35,24 @@ Hard refresh (Ctrl+F5) after HTML/CSS changes if not using Live Server.
 
 The `assets/js/` directory also contains Python scripts (`extract-*.py`, `organize-*.py`) used to process and reorganize the certificate data — these are one-off utilities, not part of the site runtime.
 
+**Watch out — these are not the files you want to edit:**
+
+- Root `about.html` and `learning.html` are **redirect stubs** (`<meta http-equiv="refresh">`) pointing at `pages/about.html` and `pages/learning.html`. Edit the versions under `pages/`, not the root stubs.
+- `archived/` holds the source certificate PDFs (organized by year, several hundred files) that the Python scripts process into `learning-data.json`. It is the data origin, not site output.
+- `tools/` contains standalone authoring utilities (SEO helper, favicon generator, GitHub Pages setup guide) — not linked from the site.
+
 ## Architecture: Bilingual System
 
-Every user-visible section must exist in **both English and French**. The language toggle sets `data-lang` on `<html>` and toggles visibility using CSS. Convention:
+Every user-visible section must exist in **both English and French**, and the page ships **both copies in the DOM at once** — the toggle changes which is visible, it does not load content. There are two layers:
 
-- English sections/IDs: `section-id`
-- French sections/IDs: `section-id-fr`
-- The `lang` attribute value (`en` / `fr`) drives suffix logic in JS: `const suffix = lang === 'fr' ? '-fr' : ''`
+1. **Wrapper level:** the entire EN body lives in `<div id="en" class="lang-content">` and the FR body in `<div id="fr" class="lang-content">`. `setLanguage(lang)` removes `active` from all `.lang-content`, adds it to the chosen one, sets both `lang` and `data-lang` on `<html>`, and persists to `localStorage` (`language`).
+2. **Section level:** matching sections are mirrored by ID suffix — `summary` / `summary-fr`, `contact` / `contact-fr`, etc. JS that targets a section (sidebar scrollspy, anchors) derives the suffix from the active language: `const suffix = lang === 'fr' ? '-fr' : ''`.
 
-When adding content, always duplicate it in the other language or the toggle will show an empty section.
+When adding content you must duplicate it into **both** wrapper divs and give the FR copy the `-fr` ID suffix, or the toggle/sidebar will land on an empty section.
+
+## Theming
+
+Light/dark theme is set via `data-theme` on `<html>` (default light; `data-theme="dark"` for dark). The choice is persisted to `localStorage` (`theme`) and falls back to the OS `prefers-color-scheme` on first visit; an inline pre-paint snippet in each page `<head>` applies it before first render. All colors come from CSS custom properties in `style.css` — use `var(--…)`, never hardcode. The palette is a deliberate **warm graphite + amber** scheme; amber is the only accent hue — do not introduce blue/cold accents. Amber contrast rules: small text in light mode uses `--accent-text`, filled amber surfaces use dark `--accent-contrast` text (never white). See `.cursorrules` for the full token table. Verify both themes after any visual change.
 
 ## Coding Conventions
 
@@ -54,7 +63,11 @@ When adding content, always duplicate it in the other language or the toggle wil
 
 ## SEO Conventions
 
-Each page carries a full SEO head block: `<title>`, meta description/keywords, Open Graph, Twitter Card, JSON-LD structured data, canonical URL, and hreflang alternates. When adding or modifying a page, keep all of these consistent. Refer to `docs/SEO-GUIDE.md` for the keyword strategy.
+Each page carries a full SEO head block: `<title>`, meta description/keywords, Open Graph, Twitter Card, JSON-LD structured data (BreadcrumbList + Person, plus FAQPage where relevant), canonical URL, and hreflang alternates (`en` / `fr` / `x-default`). When adding or modifying a page, keep all of these consistent. Refer to `docs/SEO-GUIDE.md` for the keyword strategy.
+
+## Related Guidance & Conventions
+
+This repo also carries `AGENTS.md` and `.cursorrules`. `.cursorrules` is the authoritative, detailed spec for the **design system** (color tokens, typography, spacing, breakpoints), accessibility requirements (skip links, ARIA, focus states, WCAG AA contrast), and per-page SEO/structured-data checklists — consult it before substantial UI or content work rather than re-deriving these. Open enhancement work and priorities are tracked in `docs/TODO.md`.
 
 ## Git & PR Workflow
 

--- a/README.md
+++ b/README.md
@@ -8,23 +8,25 @@ Visit the live portfolio at: [https://brbousnguar.github.io/](https://brbousngua
 
 ## 📋 About
 
-This repository contains the source code for my personal portfolio website showcasing my expertise as a SAP Commerce Cloud consultant and Mulesoft integrator with 8+ years of experience in Java, e-commerce architectures, and cloud-native systems.
+This repository contains the source code for my personal portfolio website showcasing my expertise as a SAP Commerce Cloud consultant and Mulesoft integrator with 9+ years of experience in Java, e-commerce architectures, and cloud-native systems.
 
 ## 🛠️ Technologies Used
 
 - **HTML5** - Semantic markup and structure
 - **CSS3** - Modern styling with gradients, animations, and responsive design
 - **JavaScript** - Interactive language switching and dynamic content
-- **Google Fonts** - Typography (Inter & Poppins)
+- **Google Fonts** - Typography (Inter)
 - **GitHub Pages** - Static site hosting
 
 ## 🎨 Features
 
 - **Bilingual Support** - English and French language toggle
-- **Responsive Design** - Mobile-first approach with modern glassmorphism effects
+- **Light/Dark Themes** - Warm graphite + amber palette driven by CSS custom properties
+- **Responsive Design** - Mobile-first approach with glassmorphism touches
 - **SEO Optimized** - Meta tags, Open Graph, Twitter Cards, and JSON-LD structured data
-- **Professional Layout** - Clean, modern design with gradient backgrounds
-- **Interactive Elements** - Hover effects, smooth transitions, and dynamic content
+- **AI-Agent Ready** - llms.txt and profile.json machine-readable profile
+- **Professional Layout** - Hero with proof stats and a bento project grid
+- **Interactive Elements** - Scroll-reveal animations, stat counters, smooth transitions (with `prefers-reduced-motion` support)
 - **CV Download** - Direct PDF download functionality
 - **Contact Integration** - Direct email and social media links
 

--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -19,7 +19,7 @@ h3 {
 }
 
 .nav-back a {
-  color: var(--accent-blue);
+  color: var(--accent-text);
   text-decoration: none;
   font-weight: 500;
   display: inline-flex;
@@ -34,10 +34,10 @@ h3 {
 }
 
 .nav-back a:hover {
-  background: var(--accent-blue);
-  color: white;
+  background: var(--accent);
+  color: var(--accent-contrast);
   text-decoration: none;
-  border-color: var(--accent-blue);
+  border-color: var(--accent);
   box-shadow: var(--shadow-sm);
 }
 
@@ -76,8 +76,8 @@ h3 {
 
 .card-number {
   display: inline-block;
-  background: var(--accent-blue);
-  color: white;
+  background: var(--accent);
+  color: var(--accent-contrast);
   font-size: 0.875rem;
   font-weight: 600;
   padding: 0.25rem 0.625rem;
@@ -87,18 +87,18 @@ h3 {
 }
 
 .cta-section {
-  background: var(--accent-blue);
-  color: white;
+  background: var(--accent);
+  color: var(--accent-contrast);
   padding: 3rem 2.5rem;
   border-radius: 0;
   text-align: center;
   margin: 4rem 0 2rem;
   box-shadow: var(--shadow-lg);
-  border: 1px solid var(--accent-blue);
+  border: 1px solid var(--accent);
 }
 
 .cta-section h3 {
-  color: white;
+  color: var(--accent-contrast);
   margin-top: 0;
   font-size: clamp(1.5rem, 3vw, 1.875rem);
   font-weight: 600;
@@ -106,7 +106,7 @@ h3 {
 }
 
 .cta-section p {
-  color: rgba(255, 255, 255, 0.95);
+  color: var(--accent-contrast);
   font-size: 1.0625rem;
   max-width: 600px;
   margin: 1rem auto;
@@ -114,8 +114,8 @@ h3 {
 
 .cta-button {
   display: inline-block;
-  background: white;
-  color: var(--accent-blue);
+  background: var(--surface-dark);
+  color: var(--accent-text);
   padding: 0.875rem 2rem;
   border-radius: 6px;
   text-decoration: none;
@@ -146,7 +146,7 @@ h3 {
 .timeline-dot {
   width: 10px;
   height: 10px;
-  background: var(--accent-blue);
+  background: var(--accent);
   border-radius: 50%;
   margin-right: 1rem;
   margin-top: 0.5rem;
@@ -160,7 +160,7 @@ h3 {
 
 .timeline-year {
   font-weight: 600;
-  color: var(--accent-blue);
+  color: var(--accent-text);
   font-size: 0.9375rem;
   font-family: inherit;
   margin-bottom: 0.25rem;
@@ -241,8 +241,8 @@ h3 {
 
 .skill-item:hover {
   background: var(--accent-light);
-  color: var(--accent-blue);
-  border-color: var(--accent-blue);
+  color: var(--accent-text);
+  border-color: var(--accent);
 }
 
 .soft-skills {
@@ -253,7 +253,7 @@ h3 {
 
 .soft-skill-item {
   background: var(--accent-light);
-  color: var(--accent-blue);
+  color: var(--accent-text);
   padding: 0.875rem;
   border-radius: 4px;
   text-align: center;
@@ -264,9 +264,9 @@ h3 {
 }
 
 .soft-skill-item:hover {
-  background: var(--accent-blue);
-  color: white;
-  border-color: var(--accent-blue);
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: var(--accent);
 }
 
 /* Responsive Design for About Page */

--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -14,6 +14,14 @@ h3 {
   font-size: clamp(1.1rem, 3vw, 1.3rem);
 }
 
+.about-intro {
+  font-size: clamp(1rem, 0.9rem + 0.5vw, 1.125rem);
+  color: var(--text-secondary);
+  margin-bottom: 2rem;
+  font-weight: 400;
+  max-width: 70ch;
+}
+
 .nav-back {
   margin-bottom: 1.5rem;
 }

--- a/assets/css/learning.css
+++ b/assets/css/learning.css
@@ -146,7 +146,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--accent-blue);
+  color: var(--accent);
   flex-shrink: 0;
 }
 
@@ -165,7 +165,7 @@
 .stat-card-large .stat-number {
   font-size: 2.5rem;
   font-weight: 700;
-  color: var(--accent-blue);
+  color: var(--accent);
   line-height: 1.2;
   margin-bottom: 0.25rem;
   width: 100%;
@@ -205,7 +205,7 @@
 
 .search-box input:focus {
   outline: none;
-  border-color: var(--accent-blue);
+  border-color: var(--accent);
 }
 
 .search-icon {
@@ -274,16 +274,16 @@
 }
 
 .skill-filter-btn:hover {
-  background: var(--accent-blue);
-  color: white;
-  border-color: var(--accent-blue);
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: var(--accent);
   transform: translateY(-1px);
 }
 
 .skill-filter-btn.active {
-  background: var(--accent-blue);
-  color: white;
-  border-color: var(--accent-blue);
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: var(--accent);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
@@ -338,7 +338,7 @@
 
 .filter-group select:focus {
   outline: none;
-  border-color: var(--accent-blue);
+  border-color: var(--accent);
 }
 
 .clear-filters-btn {
@@ -355,8 +355,8 @@
 
 .clear-filters-btn:hover {
   background: var(--accent-light);
-  border-color: var(--accent-blue);
-  color: var(--accent-blue);
+  border-color: var(--accent-text);
+  color: var(--accent);
 }
 
 .active-filters {
@@ -372,7 +372,7 @@
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
   background: var(--accent-light);
-  color: var(--accent-blue);
+  color: var(--accent-text);
   border-radius: 16px;
   font-size: 0.875rem;
   font-weight: 500;
@@ -381,7 +381,7 @@
 .filter-tag button {
   background: none;
   border: none;
-  color: var(--accent-blue);
+  color: var(--accent-text);
   cursor: pointer;
   font-size: 1rem;
   line-height: 1;
@@ -434,8 +434,8 @@
 }
 
 .view-btn.active {
-  background: var(--accent-blue);
-  color: white;
+  background: var(--accent);
+  color: var(--accent-contrast);
 }
 
 .view-btn:hover:not(.active) {
@@ -544,7 +544,7 @@
 .certificate-card-learning:hover {
   transform: translateY(-2px);
   box-shadow: var(--shadow-md);
-  border-color: var(--accent-blue);
+  border-color: var(--accent);
 }
 
 .certificate-header-learning {
@@ -568,7 +568,7 @@
 
 .certificate-badge-learning {
   background: var(--accent-light);
-  color: var(--accent-blue);
+  color: var(--accent-text);
   padding: 0.25rem 0.75rem;
   border-radius: 12px;
   font-size: 0.75rem;
@@ -656,7 +656,7 @@
 }
 
 .certificate-link-learning {
-  color: var(--accent-blue);
+  color: var(--accent-text);
   text-decoration: none;
   font-weight: 600;
   font-size: 0.9375rem;
@@ -695,7 +695,7 @@
   padding: 2.5rem;
   background: var(--surface-light);
   border-radius: 12px;
-  border-left: 4px solid var(--accent-blue);
+  border-left: 4px solid var(--accent);
   max-width: 1000px;
   margin-left: auto;
   margin-right: auto;
@@ -728,7 +728,7 @@
 }
 
 .philosophy-point strong {
-  color: var(--accent-blue);
+  color: var(--accent-text);
   display: block;
   margin-bottom: 0.5rem;
   font-size: 1rem;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -518,63 +518,12 @@ strong {
   border-color: var(--accent);
 }
 
-.nav-links {
-  display: flex;
-  gap: 0.75rem;
-  margin: 2rem 0;
-  flex-wrap: wrap;
-}
 
-.nav-link-primary {
-  color: var(--accent-contrast);
-  text-decoration: none;
-  font-weight: 600;
-  padding: 0.625rem 1.25rem;
-  border-radius: 6px;
-  background: var(--accent);
-  transition: all 0.2s ease;
-  border: 1px solid var(--accent);
-  font-size: 14px;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  box-shadow: var(--shadow-sm);
-}
 
-.nav-link-primary svg {
-  flex-shrink: 0;
-}
 
-.nav-link-primary:hover {
-  background: var(--accent-hover);
-  border-color: var(--accent-hover);
-  color: var(--accent-contrast);
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-md);
-}
 
-.nav-link-secondary {
-  color: var(--text-secondary);
-  text-decoration: none;
-  font-weight: 500;
-  padding: 0.625rem 1.25rem;
-  border-radius: 6px;
-  background: transparent;
-  transition: all 0.2s ease;
-  border: 1px solid var(--border-medium);
-  font-size: 14px;
-}
 
-.nav-link-secondary:hover {
-  background: var(--surface-light);
-  color: var(--text-primary);
-  border-color: var(--accent);
-}
 
-.nav-links a:focus {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
 
 .logo:focus {
   outline: 2px solid var(--accent);
@@ -597,10 +546,6 @@ strong {
   .main-content {
     padding: 2rem 1.5rem;
     margin: 0;
-  }
-  
-  .professional-header {
-    gap: 1.5rem;
   }
 }
 
@@ -720,61 +665,15 @@ strong {
     display: none;
   }
   
-  /* Quick Action Links - Small top margin to prevent overlap with sticky nav */
-  .nav-links {
-    display: flex;
-    gap: 0.5rem;
-    margin: 0.75rem 0 1rem 0 !important;
-    padding: 0 !important;
-    flex-wrap: wrap;
-  }
-  
-  .nav-link-primary,
-  .nav-link-secondary {
-    flex: 1;
-    min-width: 120px;
-    min-height: 44px; /* Touch-friendly */
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-  }
   
   .lang-content {
     margin: 0;
     padding: 0;
   }
   
-  /* Professional Header - Mobile Optimized */
-  .professional-header {
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-    gap: 1rem;
-    padding: 1.5rem 0 0 0;
-    margin: 0 0 1.5rem 0;
-    border-bottom: 2px solid var(--border-subtle);
-  }
   
-  .profile-img {
-    width: 100px;
-    height: 100px;
-  }
   
-  .header-content h1 {
-    font-size: 1.75rem;
-    margin: 0.5rem 0;
-  }
   
-  .title-line {
-    font-size: 1rem;
-    margin: 0.25rem 0;
-  }
-  
-  .experience-line {
-    font-size: 0.875rem;
-    margin: 0.25rem 0;
-  }
   
   /* Typography adjustments */
   h1 {
@@ -914,11 +813,6 @@ strong {
     padding-top: 0 !important;
   }
   
-  .nav-links {
-    margin-top: 0 !important;
-    padding-top: 0 !important;
-  }
-  
   .top-header {
     padding: 0.625rem 0.75rem;
   }
@@ -982,41 +876,11 @@ strong {
     min-height: 38px; /* Compact but still touch-friendly */
   }
   
-  /* Professional Header - Compact */
-  .professional-header {
-    padding: 1.25rem 0 0 0;
-    margin-bottom: 1.25rem;
-    gap: 0.875rem;
-  }
   
-  .profile-img {
-    width: 90px;
-    height: 90px;
-  }
   
-  .header-content h1 {
-    font-size: 1.5rem;
-  }
   
-  .title-line {
-    font-size: 0.9375rem;
-  }
   
-  .experience-line {
-    font-size: 0.8125rem;
-  }
   
-  /* Quick Links - Stack on very small screens */
-  .nav-links {
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-  
-  .nav-link-primary,
-  .nav-link-secondary {
-    width: 100%;
-    min-width: auto;
-  }
   
   /* Typography */
   h1 {
@@ -1089,75 +953,14 @@ strong {
   }
 }
 
-/* ============================================
-   PROFESSIONAL MINIMALIST HEADER
-   ============================================ */
-.professional-header {
-  display: flex;
-  align-items: center;
-  gap: 2rem;
-  padding: 2.5rem 0;
-  margin-bottom: 3rem;
-  border-bottom: 2px solid var(--border-subtle);
-  position: relative;
-}
 
-.professional-header::after {
-  content: '';
-  position: absolute;
-  bottom: -2px;
-  left: 0;
-  width: 80px;
-  height: 2px;
-  background: var(--accent);
-}
 
-.header-left {
-  flex-shrink: 0;
-}
 
-.profile-img {
-  width: 120px;
-  height: 120px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 3px solid var(--accent);
-  box-shadow: var(--shadow-md);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
 
-.profile-img:hover {
-  transform: scale(1.05);
-  box-shadow: var(--shadow-lg);
-}
 
-.header-content {
-  flex: 1;
-}
 
-.header-content h1 {
-  font-size: 2rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  margin: 0 0 0.5rem 0;
-  letter-spacing: -0.02em;
-  line-height: 1.2;
-}
 
-.title-line {
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: var(--accent-text);
-  margin: 0 0 0.375rem 0;
-  letter-spacing: -0.01em;
-}
 
-.experience-line {
-  font-size: 0.9375rem;
-  color: var(--text-secondary);
-  margin: 0;
-  line-height: 1.5;
-}
 
 /* ============================================
    PROFESSIONAL PROJECT ENTRIES
@@ -1375,32 +1178,10 @@ strong {
    ENHANCED RESPONSIVE DESIGN
    ============================================ */
 @media (max-width: 768px) {
-  .professional-header {
-    flex-direction: column;
-    align-items: flex-start;
-    text-align: left;
-    gap: 1.25rem;
-    padding: 0;
-    margin-top: 0;
-    margin-bottom: 1.5rem;
-  }
   
-  .profile-img {
-    width: 100px;
-    height: 100px;
-  }
   
-  .header-content h1 {
-    font-size: 1.5rem;
-  }
   
-  .title-line {
-    font-size: 1rem;
-  }
   
-  .experience-line {
-    font-size: 0.875rem;
-  }
   
   .project-header {
     flex-direction: column;
@@ -1849,6 +1630,242 @@ strong {
 }
 
 /* ============================================
+   HERO
+   ============================================ */
+.section[id] {
+  scroll-margin-top: 90px;
+}
+
+.hero {
+  position: relative;
+  padding: 2.5rem 2.5rem 2rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background:
+    radial-gradient(ellipse 80% 60% at 85% 10%, var(--accent-light) 0%, transparent 60%),
+    var(--surface-dark);
+  overflow: hidden;
+  margin-bottom: 2.5rem;
+}
+
+.hero-inner {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.hero-kicker {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent-text);
+  margin: 0 0 0.75rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.25rem, 4.5vw + 0.5rem, 3.25rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+  margin: 0 0 1rem;
+}
+
+.hero-tagline {
+  font-size: clamp(1.125rem, 1vw + 0.9rem, 1.375rem);
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.4;
+  margin: 0 0 1rem;
+}
+
+.hero-summary {
+  color: var(--text-secondary);
+  max-width: 56ch;
+  margin: 0 0 1.75rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.875rem;
+  margin-bottom: 1.25rem;
+}
+
+.btn-primary,
+.btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  font-size: 0.9375rem;
+  text-decoration: none;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast),
+    background-color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border: 1px solid var(--accent);
+}
+
+.btn-primary:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid var(--border-medium);
+}
+
+.btn-secondary:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-sm);
+}
+
+.hero-social {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  font-size: 0.875rem;
+}
+
+.hero-social a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-weight: 500;
+  transition: color var(--transition-fast);
+}
+
+.hero-social a:hover {
+  color: var(--accent-text);
+}
+
+.hero-social-sep {
+  color: var(--border-medium);
+}
+
+.hero-portrait {
+  display: flex;
+  justify-content: center;
+}
+
+.hero-portrait-card {
+  background: var(--glass-bg);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  text-align: center;
+  box-shadow: var(--shadow-lg);
+}
+
+@supports not (backdrop-filter: blur(1px)) {
+  .hero-portrait-card {
+    background: var(--surface-dark);
+  }
+}
+
+.hero-img {
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 3px solid var(--accent);
+  box-shadow: var(--shadow-md);
+}
+
+.hero-portrait-caption {
+  margin: 1rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  margin-top: 2.25rem;
+}
+
+.hero-stat {
+  background: var(--surface-dark);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: 1.25rem 1rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.hero-stat:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.hero-stat-number {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--accent);
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+}
+
+.hero-stat-label {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+@media (max-width: 900px) {
+  .hero-inner {
+    grid-template-columns: 1fr;
+    gap: 1.75rem;
+  }
+
+  .hero-portrait {
+    order: -1;
+    justify-content: flex-start;
+  }
+
+  .hero-portrait-card {
+    padding: 1rem;
+  }
+
+  .hero-img {
+    width: 120px;
+    height: 120px;
+  }
+
+  .hero-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .hero {
+    padding: 1.5rem 1.25rem;
+  }
+
+  .hero-actions .btn-primary,
+  .hero-actions .btn-secondary {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+/* ============================================
    SCROLL REVEAL MOTION SYSTEM
    Hidden state is gated behind html.js so content
    is always visible when JavaScript is unavailable.
@@ -1898,16 +1915,11 @@ html.js .reveal.is-visible {
   .sidebar,
   .back-to-top,
   .theme-toggle,
-  .lang-toggle,
-  .nav-links {
+  .lang-toggle {
     display: none;
   }
-  
+
   .page-wrapper {
     display: block;
-  }
-  
-  .professional-header {
-    page-break-inside: avoid;
   }
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,41 +1,58 @@
 :root {
-  /* Warm Sepia/Yellow/Gold Theme */
-  --primary-bg: #faf8f3;
-  --secondary-bg: #f5f1e8;
-  --sidebar-bg: #f8f5ed;
-  --accent-blue: #d4a04f;
-  --accent-hover: #b8894a;
-  --accent-light: #f9f0de;
-  --text-primary: #2d2416;
-  --text-secondary: #5a4a34;
-  --text-muted: #8b7a5e;
+  /* Warm Graphite + Amber Theme (light) */
+  --primary-bg: #faf9f7;
+  --secondary-bg: #f5f4f2;
+  --sidebar-bg: #f7f6f4;
+  --accent: #d97706;
+  --accent-hover: #b45309;
+  --accent-text: #92400e;      /* AA-safe amber for small text/links on light surfaces */
+  --accent-contrast: #1c1917;  /* text color on filled amber surfaces */
+  --accent-light: #fdf0df;
+  --text-primary: #1c1917;
+  --text-secondary: #44403c;
+  --text-muted: #78716c;
   --surface-dark: #ffffff;
-  --surface-light: #f9f6ed;
-  --border-subtle: #e8dfc8;
-  --border-medium: #d4c9b0;
-  --shadow-sm: 0 1px 2px 0 rgba(45, 36, 22, 0.05);
-  --shadow-md: 0 2px 4px 0 rgba(45, 36, 22, 0.08);
-  --shadow-lg: 0 4px 6px -1px rgba(45, 36, 22, 0.1);
-  --shadow-xl: 0 10px 15px -3px rgba(45, 36, 22, 0.12);
+  --surface-light: #faf9f7;
+  --border-subtle: #e7e5e4;
+  --border-medium: #d6d3d1;
+  --shadow-sm: 0 1px 2px 0 rgba(28, 25, 23, 0.05);
+  --shadow-md: 0 2px 6px -1px rgba(28, 25, 23, 0.08);
+  --shadow-lg: 0 8px 20px -4px rgba(28, 25, 23, 0.10);
+  --shadow-xl: 0 16px 40px -8px rgba(28, 25, 23, 0.14);
+  --glass-bg: rgba(255, 255, 255, 0.72);
+  --glass-border: rgba(28, 25, 23, 0.08);
+  --transition-fast: 150ms ease;
+  --transition-base: 250ms ease;
+  --transition-slow: 400ms ease;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
 }
 
 [data-theme="dark"] {
-  /* Dark Sepia Theme */
-  --primary-bg: #1a1510;
-  --secondary-bg: #2a2318;
-  --sidebar-bg: #221c14;
-  --text-primary: #e8dfc8;
-  --text-secondary: #c4b89e;
-  --text-muted: #8b7a5e;
-  --surface-dark: #2a2318;
-  --surface-light: #3a2f20;
-  --border-subtle: #3a2f20;
-  --border-medium: #4a3d28;
-  --accent-light: #3d2f1a;
+  /* Warm Graphite + Amber Theme (dark) */
+  --primary-bg: #121110;
+  --secondary-bg: #1c1a18;
+  --sidebar-bg: #181614;
+  --accent: #f59e0b;
+  --accent-hover: #fbbf24;
+  --accent-text: #f59e0b;
+  --accent-contrast: #1c1917;
+  --accent-light: #2e2113;
+  --text-primary: #f5f4f2;
+  --text-secondary: #d6d3d1;
+  --text-muted: #a8a29e;
+  --surface-dark: #1c1a18;
+  --surface-light: #262321;
+  --border-subtle: #2b2826;
+  --border-medium: #3a3633;
   --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.4);
-  --shadow-md: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
-  --shadow-lg: 0 4px 6px -1px rgba(0, 0, 0, 0.6);
-  --shadow-xl: 0 10px 15px -3px rgba(0, 0, 0, 0.7);
+  --shadow-md: 0 2px 6px -1px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 8px 20px -4px rgba(0, 0, 0, 0.6);
+  --shadow-xl: 0 16px 40px -8px rgba(0, 0, 0, 0.7);
+  --glass-bg: rgba(28, 26, 24, 0.72);
+  --glass-border: rgba(245, 244, 242, 0.08);
 }
 
 * {
@@ -47,8 +64,8 @@
   position: absolute;
   top: -40px;
   left: 0;
-  background: var(--accent-blue);
-  color: white;
+  background: var(--accent);
+  color: var(--accent-contrast);
   padding: 8px 16px;
   text-decoration: none;
   z-index: 1000;
@@ -121,13 +138,13 @@ body {
   padding: 4px;
   background: var(--secondary-bg);
   border: 1px solid var(--border-subtle);
-  box-shadow: 0 3px 8px rgba(212, 160, 79, 0.25);
+  box-shadow: 0 3px 8px rgba(217, 119, 6, 0.25);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .logo:hover .logo-mark {
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(212, 160, 79, 0.35);
+  box-shadow: 0 4px 12px rgba(217, 119, 6, 0.35);
 }
 
 .logo-name {
@@ -247,13 +264,13 @@ body {
 }
 
 .sidebar-nav a:focus {
-  outline: 2px solid var(--accent-blue);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
 .sidebar-nav a.active {
   background: var(--accent-light);
-  color: var(--accent-blue);
+  color: var(--accent-text);
   font-weight: 600;
   position: relative;
   padding-left: 1.25rem;
@@ -267,7 +284,7 @@ body {
   transform: translateY(-50%);
   width: 3px;
   height: 16px;
-  background: var(--accent-blue);
+  background: var(--accent);
   border-radius: 2px;
 }
 
@@ -306,7 +323,7 @@ body {
 }
 
 .breadcrumb a:hover {
-  color: var(--accent-blue);
+  color: var(--accent-text);
 }
 
 .breadcrumb .separator {
@@ -345,7 +362,7 @@ h2::after {
   left: 0;
   width: 40px;
   height: 2px;
-  background: var(--accent-blue);
+  background: var(--accent);
   border-radius: 2px;
 }
 
@@ -411,7 +428,7 @@ strong {
 .section-content:hover {
   box-shadow: var(--shadow-md);
   border-color: var(--border-medium);
-  border-left-color: var(--accent-blue);
+  border-left-color: var(--accent);
   transform: translateY(-2px);
 }
 .tag {
@@ -430,8 +447,8 @@ strong {
 
 .tag:hover {
   background: var(--accent-light);
-  color: var(--accent-blue);
-  border-color: var(--accent-blue);
+  color: var(--accent-text);
+  border-color: var(--accent);
 }
 .lang-toggle {
   display: flex;
@@ -465,7 +482,7 @@ strong {
 
 .lang-toggle button.active {
   background: var(--surface-dark);
-  border-color: var(--accent-blue);
+  border-color: var(--accent);
   box-shadow: var(--shadow-sm);
 }
 
@@ -495,10 +512,10 @@ strong {
 }
 
 .social a:hover {
-  background: var(--accent-blue);
-  color: white;
+  background: var(--accent);
+  color: var(--accent-contrast);
   text-decoration: none;
-  border-color: var(--accent-blue);
+  border-color: var(--accent);
 }
 
 .nav-links {
@@ -509,14 +526,14 @@ strong {
 }
 
 .nav-link-primary {
-  color: white;
+  color: var(--accent-contrast);
   text-decoration: none;
   font-weight: 600;
   padding: 0.625rem 1.25rem;
   border-radius: 6px;
-  background: var(--accent-blue);
+  background: var(--accent);
   transition: all 0.2s ease;
-  border: 1px solid var(--accent-blue);
+  border: 1px solid var(--accent);
   font-size: 14px;
   display: inline-flex;
   align-items: center;
@@ -531,7 +548,7 @@ strong {
 .nav-link-primary:hover {
   background: var(--accent-hover);
   border-color: var(--accent-hover);
-  color: white;
+  color: var(--accent-contrast);
   transform: translateY(-1px);
   box-shadow: var(--shadow-md);
 }
@@ -551,16 +568,16 @@ strong {
 .nav-link-secondary:hover {
   background: var(--surface-light);
   color: var(--text-primary);
-  border-color: var(--accent-blue);
+  border-color: var(--accent);
 }
 
 .nav-links a:focus {
-  outline: 2px solid var(--accent-blue);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
 .logo:focus {
-  outline: 2px solid var(--accent-blue);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
   border-radius: 4px;
 }
@@ -1092,7 +1109,7 @@ strong {
   left: 0;
   width: 80px;
   height: 2px;
-  background: var(--accent-blue);
+  background: var(--accent);
 }
 
 .header-left {
@@ -1104,7 +1121,7 @@ strong {
   height: 120px;
   border-radius: 50%;
   object-fit: cover;
-  border: 3px solid var(--accent-blue);
+  border: 3px solid var(--accent);
   box-shadow: var(--shadow-md);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
@@ -1130,7 +1147,7 @@ strong {
 .title-line {
   font-size: 1.125rem;
   font-weight: 600;
-  color: var(--accent-blue);
+  color: var(--accent-text);
   margin: 0 0 0.375rem 0;
   letter-spacing: -0.01em;
 }
@@ -1261,14 +1278,14 @@ strong {
   top: 1.25rem;
   width: 10px;
   height: 10px;
-  background: var(--accent-blue);
+  background: var(--accent);
   border-radius: 50%;
   border: 2px solid var(--surface-dark);
   box-shadow: 0 0 0 2px var(--accent-light);
 }
 
 .value-point:hover {
-  border-left-color: var(--accent-blue);
+  border-left-color: var(--accent);
   padding-left: 2.25rem;
 }
 
@@ -1326,8 +1343,8 @@ strong {
   position: fixed;
   bottom: 2rem;
   right: 2rem;
-  background: var(--accent-blue);
-  color: white;
+  background: var(--accent);
+  color: var(--accent-contrast);
   width: 44px;
   height: 44px;
   border-radius: 8px;
@@ -1474,7 +1491,7 @@ strong {
 .stat-number-compact {
   font-size: 2rem;
   font-weight: 700;
-  color: var(--accent-blue);
+  color: var(--accent);
   line-height: 1.2;
 }
 
@@ -1496,8 +1513,8 @@ strong {
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1.5rem;
-  background: var(--accent-blue);
-  color: white;
+  background: var(--accent);
+  color: var(--accent-contrast);
   text-decoration: none;
   border-radius: 8px;
   font-weight: 600;
@@ -1547,7 +1564,7 @@ strong {
 .stat-number {
   font-size: 2.5rem;
   font-weight: 700;
-  color: var(--accent-blue);
+  color: var(--accent);
   line-height: 1.2;
   margin-bottom: 0.5rem;
 }
@@ -1573,7 +1590,7 @@ strong {
   padding: 1.5rem;
   background: var(--surface-light);
   border-radius: 8px;
-  border-left: 4px solid var(--accent-blue);
+  border-left: 4px solid var(--accent);
 }
 
 .domain-title {
@@ -1613,7 +1630,7 @@ strong {
 .certificate-card:hover {
   transform: translateY(-2px);
   box-shadow: var(--shadow-md);
-  border-color: var(--accent-blue);
+  border-color: var(--accent);
 }
 
 .certificate-header {
@@ -1635,7 +1652,7 @@ strong {
 
 .certificate-badge {
   background: var(--accent-light);
-  color: var(--accent-blue);
+  color: var(--accent-text);
   padding: 0.25rem 0.75rem;
   border-radius: 12px;
   font-size: 0.75rem;
@@ -1675,7 +1692,7 @@ strong {
 }
 
 .certificate-link {
-  color: var(--accent-blue);
+  color: var(--accent-text);
   text-decoration: none;
   font-weight: 600;
   font-size: 0.9375rem;
@@ -1689,6 +1706,17 @@ strong {
 .certificate-link:hover {
   color: var(--accent-hover);
   gap: 0.75rem;
+}
+
+.contact-email {
+  color: var(--accent-text);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.contact-email:hover {
+  color: var(--accent-hover);
+  text-decoration: underline;
 }
 
 .domain-placeholder {
@@ -1706,7 +1734,7 @@ strong {
   padding: 2rem;
   background: var(--surface-light);
   border-radius: 8px;
-  border-left: 4px solid var(--accent-blue);
+  border-left: 4px solid var(--accent);
 }
 
 .learning-philosophy h3 {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -101,7 +101,9 @@ body {
 
 /* Top Header Bar */
 .top-header {
-  background: var(--surface-dark);
+  background: var(--glass-bg);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--border-subtle);
   padding: 0.75rem 2rem;
   display: flex;
@@ -111,6 +113,12 @@ body {
   top: 0;
   z-index: 100;
   transition: background-color 0.2s ease;
+}
+
+@supports not (backdrop-filter: blur(1px)) {
+  .top-header {
+    background: var(--surface-dark);
+  }
 }
 
 .logo {
@@ -334,7 +342,7 @@ body {
 h1 {
   font-family: -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
   color: var(--text-primary);
-  font-size: 2.5rem;
+  font-size: clamp(2rem, 1.5rem + 2vw, 2.5rem);
   font-weight: 700;
   margin-bottom: 1rem;
   margin-top: 0;
@@ -345,7 +353,7 @@ h1 {
 h2 {
   font-family: -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
   color: var(--text-primary);
-  font-size: 1.75rem;
+  font-size: clamp(1.4rem, 1.15rem + 1.2vw, 1.75rem);
   font-weight: 600;
   margin-bottom: 1.25rem;
   margin-top: 2.5rem;
@@ -373,7 +381,7 @@ h2:first-of-type {
 h3 {
   font-family: -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
   color: var(--text-primary);
-  font-size: 1.25rem;
+  font-size: clamp(1.125rem, 1rem + 0.5vw, 1.25rem);
   font-weight: 600;
   margin-bottom: 0.75rem;
   margin-top: 1.5rem;
@@ -419,7 +427,7 @@ strong {
   background: var(--surface-dark);
   border: 1px solid var(--border-subtle);
   border-left: 3px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   padding: 2rem;
   transition: all 0.2s ease;
   position: relative;
@@ -1110,9 +1118,9 @@ strong {
    VALUE PROPOSITION - PROFESSIONAL LAYOUT
    ============================================ */
 .value-points {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.25rem;
   margin-top: 1.5rem;
 }
 
@@ -1120,34 +1128,54 @@ strong {
   font-size: 0.9375rem;
   line-height: 1.7;
   color: var(--text-secondary);
-  padding: 0.75rem 0 0.75rem 2rem;
+  padding: 1.25rem 1.5rem;
   position: relative;
-  border-left: 2px solid var(--accent-light);
-  margin-left: 0.5rem;
+  background: var(--surface-light);
+  border: 1px solid var(--border-subtle);
+  border-top: 3px solid var(--accent);
+  border-radius: var(--radius-md);
   transition: all 0.2s ease;
 }
 
-.value-point::before {
-  content: '';
-  position: absolute;
-  left: -6px;
-  top: 1.25rem;
-  width: 10px;
-  height: 10px;
-  background: var(--accent);
-  border-radius: 50%;
-  border: 2px solid var(--surface-dark);
-  box-shadow: 0 0 0 2px var(--accent-light);
-}
-
 .value-point:hover {
-  border-left-color: var(--accent);
-  padding-left: 2.25rem;
+  box-shadow: var(--shadow-md);
+  border-color: var(--border-medium);
+  border-top-color: var(--accent);
 }
 
 .value-point strong {
   color: var(--text-primary);
   font-weight: 600;
+}
+
+/* Muted note (e.g. certifications in progress) */
+.note-muted {
+  margin-top: 1rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* Contact CTA band */
+.contact-cta {
+  text-align: center;
+  background:
+    radial-gradient(ellipse 70% 100% at 50% 100%, var(--accent-light) 0%, transparent 65%),
+    var(--surface-dark);
+}
+
+.contact-cta h2 {
+  margin-top: 0;
+}
+
+.contact-cta h2::after {
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.contact-cta p {
+  color: var(--text-secondary);
+  max-width: 48ch;
+  margin: 0 auto 1.5rem;
 }
 
 /* ============================================

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1849,6 +1849,48 @@ strong {
 }
 
 /* ============================================
+   SCROLL REVEAL MOTION SYSTEM
+   Hidden state is gated behind html.js so content
+   is always visible when JavaScript is unavailable.
+   ============================================ */
+html.js .reveal {
+  opacity: 0;
+  transform: translateY(18px);
+  transition:
+    opacity var(--transition-slow),
+    transform var(--transition-slow);
+  transition-delay: calc(var(--stagger-i, 0) * 70ms);
+}
+
+html.js .reveal.is-visible {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  html.js .reveal {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+
+  .section {
+    animation: none;
+  }
+
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}
+
+/* ============================================
    PRINT STYLES
    ============================================ */
 @media print {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -963,38 +963,57 @@ strong {
 
 
 /* ============================================
-   PROFESSIONAL PROJECT ENTRIES
+   BENTO PROJECT GRID (Problem / Solution / Impact)
    ============================================ */
-.projects-list {
+.bento-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.25rem;
+  margin-top: 1.75rem;
+}
+
+.project-card {
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
-  margin-top: 2rem;
+  gap: 1.25rem;
+  background: var(--surface-dark);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem;
+  box-shadow: var(--shadow-sm);
 }
 
-.project-entry {
-  position: relative;
-  padding: 1.5rem 0 2.5rem;
-  border-bottom: 1px solid var(--border-subtle);
-  transition: padding 0.2s ease;
+@media (prefers-reduced-motion: no-preference) {
+  .project-card {
+    transition: transform var(--transition-fast), box-shadow var(--transition-fast),
+      border-color var(--transition-fast);
+  }
+
+  .project-card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-lg);
+    border-color: var(--border-medium);
+  }
 }
 
-.project-entry:hover {
-  padding-left: 0.5rem;
+.project-card--feature {
+  grid-column: 1 / -1;
+  background:
+    radial-gradient(ellipse 60% 80% at 100% 0%, var(--accent-light) 0%, transparent 55%),
+    var(--surface-dark);
 }
 
-.project-entry:last-child {
-  border-bottom: none;
-  padding-bottom: 0;
+.project-card--feature .psi {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
 }
 
-.project-header {
+.project-card-head {
   display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 1rem;
-  margin-bottom: 0.75rem;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
 }
 
 .project-title {
@@ -1006,51 +1025,85 @@ strong {
 }
 
 .project-status {
-  font-size: 0.8125rem;
-  font-weight: 500;
+  font-size: 0.75rem;
+  font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   padding: 0.25rem 0.75rem;
   background: var(--secondary-bg);
   border: 1px solid var(--border-subtle);
-  border-radius: 4px;
+  border-radius: 999px;
+}
+
+.project-status--ongoing {
+  color: var(--accent-text);
+  background: var(--accent-light);
+  border-color: var(--accent);
 }
 
 .project-meta {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-bottom: 1rem;
 }
 
 .tech-tag {
   font-size: 0.8125rem;
-  color: var(--text-secondary);
+  color: var(--accent-text);
   padding: 0.25rem 0.625rem;
-  background: var(--surface-light);
-  border: 1px solid var(--border-subtle);
-  border-radius: 3px;
+  background: var(--accent-light);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
   font-weight: 500;
 }
 
-.project-description {
-  font-size: 0.9375rem;
-  line-height: 1.7;
-  color: var(--text-primary);
-  margin: 0 0 1rem 0;
+.psi {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
-.project-achievements {
-  font-size: 0.875rem;
+.psi-block p {
+  font-size: 0.9375rem;
   line-height: 1.6;
   color: var(--text-secondary);
   margin: 0;
 }
 
-.project-achievements strong {
-  color: var(--text-primary);
+.psi-label {
+  font-size: 0.75rem;
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent-text);
+  margin: 0 0 0.375rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.psi-label::before {
+  content: '';
+  width: 14px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 1px;
+}
+
+@media (max-width: 768px) {
+  .bento-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .project-card--feature .psi {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .project-card {
+    padding: 1.5rem 1.25rem;
+  }
 }
 
 /* ============================================
@@ -1178,31 +1231,8 @@ strong {
    ENHANCED RESPONSIVE DESIGN
    ============================================ */
 @media (max-width: 768px) {
-  
-  
-  
-  
-  
-  .project-header {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.5rem;
-  }
-  
   .project-title {
     font-size: 1.125rem;
-  }
-  
-  .project-description {
-    font-size: 0.875rem;
-  }
-  
-  .project-achievements {
-    font-size: 0.8125rem;
-  }
-  
-  .projects-list {
-    gap: 2rem;
   }
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1306,6 +1306,21 @@ strong {
   margin: 0;
 }
 
+.learning-focus {
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  margin: 0.875rem 0 0;
+  padding: 0.625rem 0.875rem;
+  background: var(--accent-light);
+  border-left: 3px solid var(--accent);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.learning-focus strong {
+  color: var(--accent-text);
+}
+
 .learning-journey-content {
   display: flex;
   align-items: center;

--- a/assets/js/generate-learning-schema.py
+++ b/assets/js/generate-learning-schema.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""One-off utility: regenerate the CollectionPage JSON-LD in pages/learning.html
+from assets/data/learning-data.json.
+
+Embeds the 30 most recent certificates as ListItem -> Course entries and keeps
+numberOfItems in sync with the dataset total. Run from the repo root:
+
+    python assets/js/generate-learning-schema.py
+"""
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DATA = ROOT / "assets" / "data" / "learning-data.json"
+PAGE = ROOT / "pages" / "learning.html"
+TOP_N = 30
+SITE = "https://brbousnguar.github.io"
+
+
+def build_schema(data):
+    certs = sorted(
+        data["certificates"],
+        key=lambda c: c.get("date") or "",
+        reverse=True,
+    )
+
+    items = []
+    seen = set()
+    for cert in certs:
+        key = (cert["title"], cert.get("date"))
+        if key in seen:
+            continue
+        seen.add(key)
+        item = {
+            "@type": "Course",
+            "name": cert["title"],
+            "provider": {
+                "@type": "Organization",
+                "name": cert.get("provider") or "LinkedIn Learning",
+            },
+            "datePublished": cert.get("date") or "",
+        }
+        if cert.get("duration"):
+            item["timeRequired"] = cert["duration"]
+        if cert.get("skills"):
+            item["about"] = cert["skills"]
+        items.append({
+            "@type": "ListItem",
+            "position": len(items) + 1,
+            "item": item,
+        })
+        if len(items) == TOP_N:
+            break
+
+    total = data["metadata"]["total"]
+    domains = data["metadata"]["domains"]
+    return {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "Continuous Learning & Certifications - Brahim Bousnguar",
+        "description": (
+            f"{total} LinkedIn Learning certificates across {domains} technology "
+            "domains including AI, Programming, Cloud, DevOps, and APIs"
+        ),
+        "url": f"{SITE}/pages/learning.html",
+        "mainEntity": {
+            "@type": "ItemList",
+            "numberOfItems": total,
+            "itemListElement": items,
+        },
+        "about": {
+            "@type": "Person",
+            "name": "Brahim Bousnguar",
+            "jobTitle": "Senior E-Commerce Integration Consultant",
+        },
+    }
+
+
+def main():
+    data = json.loads(DATA.read_text(encoding="utf-8"))
+    schema = build_schema(data)
+    block = json.dumps(schema, indent=2, ensure_ascii=False)
+    # Match the page's 2-space base indentation inside the <script> tag
+    block = "\n".join("  " + line for line in block.splitlines())
+
+    html = PAGE.read_text(encoding="utf-8")
+    # Replace only the JSON-LD block that contains the CollectionPage type;
+    # [^<] guards keep the match inside a single <script> element.
+    pattern = re.compile(
+        r'<script type="application/ld\+json">(?:(?!</script>).)*?"@type": "CollectionPage"(?:(?!</script>).)*?</script>',
+        re.DOTALL,
+    )
+    if not pattern.search(html):
+        raise SystemExit("CollectionPage JSON-LD block not found in learning.html")
+
+    replacement = '<script type="application/ld+json">\n' + block + "\n  </script>"
+    html = pattern.sub(lambda m: replacement, html, count=1)
+    with open(PAGE, "w", encoding="utf-8", newline="") as f:
+        f.write(html)
+    print(f"Updated {PAGE.relative_to(ROOT)}: numberOfItems={data['metadata']['total']}, "
+          f"embedded top {TOP_N} certificates")
+
+
+if __name__ == "__main__":
+    main()

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,254 @@
+/*
+ * Shared site behavior: language toggle, theme toggle, sidebar
+ * navigation (scrollspy + smooth scroll), and back-to-top button.
+ * Loaded with `defer` on every page; switchLang/toggleTheme stay
+ * global because header buttons use inline onclick attributes.
+ * The pre-paint snippet in each page <head> applies the saved theme
+ * and language attributes before first paint; this file only syncs
+ * UI state and wires up interactions.
+ */
+
+function switchLang(lang) {
+  document.querySelectorAll('.lang-content').forEach(el => el.classList.remove('active'));
+  document.querySelectorAll('.lang-toggle button').forEach(btn => btn.classList.remove('active'));
+  const selected = document.getElementById(lang);
+  if (selected) selected.classList.add('active');
+  const btn = document.querySelector(`.lang-toggle button[onclick*="${lang}"]`);
+  if (btn) btn.classList.add('active');
+
+  // Update HTML lang attribute for SEO and accessibility
+  document.documentElement.setAttribute('lang', lang);
+  document.documentElement.setAttribute('data-lang', lang);
+
+  // Save language preference to localStorage
+  localStorage.setItem('language', lang);
+
+  // Update sidebar anchors and re-init navigation (index page only)
+  if (document.querySelector('.sidebar-nav a[data-target]')) {
+    updateSidebarLang(lang);
+    initSmoothScroll();
+    initNavigationHighlight();
+  }
+
+  // Re-initialize certificate browser for the new language (learning page only)
+  if (window.initLearningPage) {
+    setTimeout(() => {
+      setupEventListeners();
+      if (window.renderSkillsFilter) {
+        renderSkillsFilter();
+      }
+      const suffix = lang === 'fr' ? '-fr' : '';
+      if (window.filteredCertificates) {
+        renderCertificates(suffix);
+        updateResultsCount(suffix);
+      }
+    }, 100);
+  }
+}
+
+function updateSidebarLang(lang) {
+  const suffix = lang === 'fr' ? '-fr' : '';
+  document.querySelectorAll('.sidebar-nav a[data-target]').forEach(link => {
+    const base = link.getAttribute('data-target');
+    link.setAttribute('href', `#${base}${suffix}`);
+  });
+}
+
+function toggleTheme() {
+  const currentTheme = document.documentElement.getAttribute('data-theme');
+  const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+
+  document.documentElement.setAttribute('data-theme', newTheme);
+  localStorage.setItem('theme', newTheme);
+  updateThemeToggle(newTheme);
+}
+
+function updateThemeToggle(theme) {
+  const lightOption = document.getElementById('light-option');
+  const darkOption = document.getElementById('dark-option');
+  if (!lightOption || !darkOption) return;
+
+  if (theme === 'light') {
+    lightOption.classList.add('active');
+    darkOption.classList.remove('active');
+  } else {
+    darkOption.classList.add('active');
+    lightOption.classList.remove('active');
+  }
+}
+
+function initNavigationHighlight() {
+  // Get only sections from the currently active language content
+  const activeContent = document.querySelector('.lang-content.active');
+  if (!activeContent) return;
+
+  const navLinks = document.querySelectorAll('.sidebar-nav a[href^="#"]');
+  if (!navLinks.length) return;
+
+  // Track if user just clicked a link
+  window.navigationClickTime = 0;
+
+  window.updateActiveNavLink = function (targetId) {
+    navLinks.forEach(link => {
+      link.classList.remove('active');
+      if (link.getAttribute('href') === targetId) {
+        link.classList.add('active');
+      }
+    });
+  };
+
+  // Remove old scroll listener if exists
+  if (window.scrollHighlightHandler) {
+    window.removeEventListener('scroll', window.scrollHighlightHandler);
+  }
+
+  // Create new scroll handler that always checks current active content
+  window.scrollHighlightHandler = function () {
+    // Don't update highlighting for 800ms after a click
+    if (Date.now() - window.navigationClickTime < 800) {
+      return;
+    }
+
+    const currentActiveContent = document.querySelector('.lang-content.active');
+    if (!currentActiveContent) return;
+
+    const currentSections = currentActiveContent.querySelectorAll('.section[id]');
+    const scrollPosition = window.scrollY + 200; // Check what's near top of viewport
+
+    let currentSection = '';
+
+    currentSections.forEach(section => {
+      const rect = section.getBoundingClientRect();
+      const sectionTop = rect.top + window.scrollY;
+      const sectionBottom = sectionTop + rect.height;
+
+      // Check if the scroll position is within this section
+      if (scrollPosition >= sectionTop && scrollPosition <= sectionBottom) {
+        currentSection = '#' + section.id;
+      }
+    });
+
+    if (currentSection && window.updateActiveNavLink) {
+      updateActiveNavLink(currentSection);
+    }
+  };
+
+  // Add the new scroll listener with throttling
+  let isScrolling = false;
+  window.addEventListener('scroll', () => {
+    if (!isScrolling) {
+      window.requestAnimationFrame(() => {
+        if (window.scrollHighlightHandler) {
+          window.scrollHighlightHandler();
+        }
+        isScrolling = false;
+      });
+    }
+    isScrolling = true;
+  });
+
+  // Trigger initial highlight check
+  if (window.scrollHighlightHandler) {
+    setTimeout(() => window.scrollHighlightHandler(), 100);
+  }
+}
+
+function initBackToTop() {
+  // Create back to top button
+  const backToTop = document.createElement('button');
+  backToTop.className = 'back-to-top';
+  backToTop.innerHTML = '↑';
+  backToTop.setAttribute('aria-label', 'Back to top');
+  backToTop.title = 'Back to top';
+  document.body.appendChild(backToTop);
+
+  // Show/hide on scroll
+  window.addEventListener('scroll', () => {
+    if (window.pageYOffset > 300) {
+      backToTop.classList.add('visible');
+    } else {
+      backToTop.classList.remove('visible');
+    }
+  });
+
+  // Scroll to top on click
+  backToTop.addEventListener('click', () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  });
+}
+
+function initSmoothScroll() {
+  // Remove old listeners by cloning and replacing navigation links
+  const navLinks = document.querySelectorAll('.sidebar-nav a[href^="#"]');
+  navLinks.forEach(link => {
+    const newLink = link.cloneNode(true);
+    link.parentNode.replaceChild(newLink, link);
+  });
+
+  // Add fresh event listeners
+  document.querySelectorAll('.sidebar-nav a[href^="#"]').forEach(anchor => {
+    anchor.addEventListener('click', function (e) {
+      e.preventDefault();
+      const targetId = this.getAttribute('href');
+
+      // Update click timestamp to prevent scroll handler from overriding
+      window.navigationClickTime = Date.now();
+
+      // Find target in active language content
+      const activeContent = document.querySelector('.lang-content.active');
+      if (!activeContent) return;
+
+      const target = activeContent.querySelector(targetId);
+      if (target) {
+        // Calculate offset for sticky header (approx 60px) + extra spacing
+        const headerOffset = 80;
+        const elementPosition = target.getBoundingClientRect().top;
+        const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
+
+        window.scrollTo({
+          top: offsetPosition,
+          behavior: 'smooth'
+        });
+
+        // Update active state immediately on click
+        if (window.updateActiveNavLink) {
+          updateActiveNavLink(targetId);
+        }
+      }
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  // The pre-paint head snippet already set data-theme / lang / data-lang;
+  // restore the language content visibility and sync toggle button states.
+  const savedLang = localStorage.getItem('language') || 'en';
+  switchLang(savedLang);
+
+  const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
+  updateThemeToggle(currentTheme);
+
+  // Follow system theme changes while the user has no explicit preference
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+    if (!localStorage.getItem('theme')) {
+      const newTheme = e.matches ? 'dark' : 'light';
+      document.documentElement.setAttribute('data-theme', newTheme);
+      updateThemeToggle(newTheme);
+    }
+  });
+
+  initBackToTop();
+
+  if (document.querySelector('.sidebar-nav a[href^="#"]')) {
+    initSmoothScroll();
+    initNavigationHighlight();
+  }
+
+  // Certificate browser (learning page only)
+  if (window.initLearningPage) {
+    initLearningPage();
+  }
+});

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -222,6 +222,70 @@ function initSmoothScroll() {
   });
 }
 
+function prefersReducedMotion() {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function initReveal() {
+  const targets = document.querySelectorAll('.reveal');
+  if (!targets.length) return;
+
+  // Stagger siblings inside any [data-stagger] container
+  document.querySelectorAll('[data-stagger]').forEach(group => {
+    Array.from(group.children).forEach((child, i) => {
+      if (child.classList.contains('reveal')) {
+        child.style.setProperty('--stagger-i', i);
+      }
+    });
+  });
+
+  if (prefersReducedMotion() || !('IntersectionObserver' in window)) {
+    targets.forEach(el => el.classList.add('is-visible'));
+    targets.forEach(el => finalizeCounters(el));
+    return;
+  }
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('is-visible');
+        animateCounters(entry.target);
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.15, rootMargin: '0px 0px -10% 0px' });
+
+  targets.forEach(el => observer.observe(el));
+}
+
+function animateCounters(scope) {
+  scope.querySelectorAll('[data-count]:not([data-counted])').forEach(el => {
+    el.setAttribute('data-counted', 'true');
+    const target = parseInt(el.getAttribute('data-count'), 10);
+    const suffix = el.getAttribute('data-suffix') || '';
+    if (isNaN(target) || prefersReducedMotion()) {
+      el.textContent = target + suffix;
+      return;
+    }
+    const duration = 1200;
+    const start = performance.now();
+    function tick(now) {
+      const progress = Math.min((now - start) / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      el.textContent = Math.round(target * eased) + (progress === 1 ? suffix : '');
+      if (progress < 1) requestAnimationFrame(tick);
+    }
+    requestAnimationFrame(tick);
+  });
+}
+
+function finalizeCounters(scope) {
+  scope.querySelectorAll('[data-count]').forEach(el => {
+    el.setAttribute('data-counted', 'true');
+    el.textContent = el.getAttribute('data-count') + (el.getAttribute('data-suffix') || '');
+  });
+}
+
 document.addEventListener('DOMContentLoaded', function () {
   // The pre-paint head snippet already set data-theme / lang / data-lang;
   // restore the language content visibility and sync toggle button states.
@@ -241,6 +305,7 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 
   initBackToTop();
+  initReveal();
 
   if (document.querySelector('.sidebar-nav a[href^="#"]')) {
     initSmoothScroll();

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -34,6 +34,7 @@ P1
 ## Follow-ups from 2026-06 redesign
 - [ ] P2 / Scope: SEO — Create a dedicated 1200x630 Open Graph banner image (currently square profile.jpeg)
 - [ ] P3 / Scope: SEO — Re-run assets/js/generate-learning-schema.py after each learning-data.json update
+- [ ] P1 / Scope: Data — Import Feb–May 2026 certificates from the Google Drive archive into `archived/2026/`, re-run the extract scripts to refresh learning-data.json (currently stops at 2026-01-19), then regenerate the learning schema
 
 ## Later / Nice-to-have
 - [ ] P2 / Scope: Visual — Add lightweight visuals (architecture diagram or simple schematic per project)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12,7 +12,7 @@ Scope: Content + structure + visual hierarchy. Keep the current stack (HTML/CSS/
 - [x] P1 / Scope: UX — Update sidebar anchors to include `#projects`, `#faq`, `#contact`
 - [x] P1 / Scope: UX — Add missing section IDs in FR blocks so sidebar works for both languages
 - [x] P1 / Scope: Maintainability — Replace inline styles on repeated blocks with CSS classes (projects cards, value props)
-- [ ] P2 / Scope: Visual — Decide on font usage: remove Poppins or apply it to headings consistently
+- [x] P2 / Scope: Visual — Decide on font usage: remove Poppins or apply it to headings consistently (Poppins removed; Inter only)
 
 ## Acceptance Criteria
 P0
@@ -25,11 +25,15 @@ P1
 - [x] Reused visual blocks (projects, value prop) are styled via CSS classes instead of inline styles
 
 ## High-Impact Enhancements (next)
-- [ ] P1 / Scope: Content+Layout — Add a hero section: 1-line positioning + 2–3 proof bullets + 2 CTAs (Contact / Download CV)
-- [ ] P1 / Scope: Content+Layout — Convert “Featured Integration Projects” into 3 card tiles with outcomes surfaced
+- [x] P1 / Scope: Content+Layout — Add a hero section: 1-line positioning + 2–3 proof bullets + 2 CTAs (Contact / Download CV)
+- [x] P1 / Scope: Content+Layout — Convert “Featured Integration Projects” into 3 card tiles with outcomes surfaced (bento grid)
 - [ ] P2 / Scope: Content — Add a credibility strip (client names/logos or text badges)
-- [ ] P1 / Scope: Content — Reformat each project to Problem / Role / Solution / Impact for faster scan
-- [ ] P2 / Scope: Layout — Improve first-view hierarchy (reduce CV density above the fold)
+- [x] P1 / Scope: Content — Reformat each project to Problem / Role / Solution / Impact for faster scan
+- [x] P2 / Scope: Layout — Improve first-view hierarchy (reduce CV density above the fold)
+
+## Follow-ups from 2026-06 redesign
+- [ ] P2 / Scope: SEO — Create a dedicated 1200x630 Open Graph banner image (currently square profile.jpeg)
+- [ ] P3 / Scope: SEO — Re-run assets/js/generate-learning-schema.py after each learning-data.json update
 
 ## Later / Nice-to-have
 - [ ] P2 / Scope: Visual — Add lightweight visuals (architecture diagram or simple schematic per project)

--- a/index.html
+++ b/index.html
@@ -56,7 +56,8 @@
   
   <link rel="icon" type="image/png" href="assets/img/favicon.png">
   <link rel="apple-touch-icon" sizes="180x180" href="assets/img/favicon.png">
-  <meta name="theme-color" content="#0066ff">
+  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#faf9f7">
+  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#121110">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <!-- Pre-paint theme/language restore (must stay inline to avoid flash of wrong theme) -->
   <script>
@@ -521,7 +522,7 @@
           <section class="section" id="contact">
             <div class="section-content">
               <h2>Contact</h2>
-              <p>Email: <a href="mailto:b.bousnguar@gmail.com" style="color: var(--accent-blue); text-decoration: none; font-weight: 600;" aria-label="Contact Brahim Bousnguar by email">b.bousnguar@gmail.com</a></p>
+              <p>Email: <a href="mailto:b.bousnguar@gmail.com" class="contact-email" aria-label="Contact Brahim Bousnguar by email">b.bousnguar@gmail.com</a></p>
             </div>
           </section>
         </div>
@@ -755,7 +756,7 @@
           <section class="section" id="contact-fr">
             <div class="section-content">
               <h2>Contact</h2>
-              <p>Email: <a href="mailto:b.bousnguar@gmail.com" style="color: var(--accent-blue); text-decoration: none; font-weight: 600;">b.bousnguar@gmail.com</a></p>
+              <p>Email: <a href="mailto:b.bousnguar@gmail.com" class="contact-email" aria-label="Contacter Brahim Bousnguar par email">b.bousnguar@gmail.com</a></p>
             </div>
           </section>
         </div>

--- a/index.html
+++ b/index.html
@@ -257,12 +257,12 @@
       <ul class="sidebar-nav">
         <li><a href="#hero" data-target="hero" class="active">Overview</a></li>
         <li><a href="#value-proposition" data-target="value-proposition">Value Proposition</a></li>
+        <li><a href="#projects" data-target="projects">Projects</a></li>
         <li><a href="#skills" data-target="skills">Skills</a></li>
         <li><a href="#certifications" data-target="certifications">Certifications</a></li>
         <li><a href="#continuous-learning" data-target="continuous-learning">Learning</a></li>
         <li><a href="pages/learning.html">All Certificates</a></li>
         <li><a href="#professional-experience" data-target="professional-experience">Experience</a></li>
-        <li><a href="#projects" data-target="projects">Projects</a></li>
         <li><a href="#education" data-target="education">Education</a></li>
         <li><a href="#faq" data-target="faq">FAQ</a></li>
         <li><a href="#contact" data-target="contact">Contact</a></li>
@@ -342,6 +342,94 @@
                 <div class="value-point">
                   <strong>AI-augmented & future-ready:</strong> Hands-on daily use of GitHub Copilot, Ollama-based LLM CLI, Claude, and OpenAI Codex CLI — AI integrated into the workflow, not just on the radar
                 </div>
+              </div>
+            </div>
+          </section>
+
+          <section class="section" id="projects">
+            <div class="section-content">
+              <h2>Featured Integration Projects</h2>
+              <div class="bento-grid" data-stagger>
+
+                <article class="project-card project-card--feature reveal">
+                  <div class="project-card-head">
+                    <span class="project-status project-status--ongoing">Ongoing</span>
+                    <h3 class="project-title">Roche Bobois — API-Led Integration Architecture</h3>
+                    <div class="project-meta">
+                      <span class="tech-tag">MuleSoft Anypoint</span>
+                      <span class="tech-tag">DataWeave</span>
+                      <span class="tech-tag">Salesforce</span>
+                      <span class="tech-tag">Orchestration</span>
+                    </div>
+                  </div>
+                  <div class="psi">
+                    <div class="psi-block">
+                      <h4 class="psi-label">Problem</h4>
+                      <p>The luxury retailer's e-commerce platform, ERP, CRM and third-party services exchanged data through fragmented point-to-point flows that were hard to monitor and evolve.</p>
+                    </div>
+                    <div class="psi-block">
+                      <h4 class="psi-label">Solution</h4>
+                      <p>API-led architecture on MuleSoft Anypoint: reusable APIs, complex DataWeave transformations, robust error handling, and orchestration patterns coordinating multi-system transactions — including Salesforce CRM data flows.</p>
+                    </div>
+                    <div class="psi-block">
+                      <h4 class="psi-label">Impact</h4>
+                      <p>A unified, observable integration backbone across order, CRM and ERP flows, with API governance standards adopted by the team and delivery accelerated by AI-augmented workflows.</p>
+                    </div>
+                  </div>
+                </article>
+
+                <article class="project-card reveal">
+                  <div class="project-card-head">
+                    <span class="project-status">Completed</span>
+                    <h3 class="project-title">Miele — Cloud-Native Commerce Migration</h3>
+                    <div class="project-meta">
+                      <span class="tech-tag">SAP Commerce Cloud CCv2</span>
+                      <span class="tech-tag">SAP BTP Kyma</span>
+                      <span class="tech-tag">Kubernetes</span>
+                    </div>
+                  </div>
+                  <div class="psi">
+                    <div class="psi-block">
+                      <h4 class="psi-label">Problem</h4>
+                      <p>A global B2C platform on on-premise SAP Hybris was limiting scalability and deployment velocity.</p>
+                    </div>
+                    <div class="psi-block">
+                      <h4 class="psi-label">Solution</h4>
+                      <p>Zero-downtime migration to SAP Commerce Cloud (CCv2), microservices on SAP BTP Kyma, OCC API optimization and Jenkins CI/CD pipelines.</p>
+                    </div>
+                    <div class="psi-block">
+                      <h4 class="psi-label">Impact</h4>
+                      <p>A cloud-native platform serving global B2C traffic with improved performance, scalability and continuous deployment.</p>
+                    </div>
+                  </div>
+                </article>
+
+                <article class="project-card reveal">
+                  <div class="project-card-head">
+                    <span class="project-status">Completed</span>
+                    <h3 class="project-title">BYK — Multi-Country B2B Platform</h3>
+                    <div class="project-meta">
+                      <span class="tech-tag">SAP Commerce Cloud</span>
+                      <span class="tech-tag">SAP ERP</span>
+                      <span class="tech-tag">OCC APIs</span>
+                    </div>
+                  </div>
+                  <div class="psi">
+                    <div class="psi-block">
+                      <h4 class="psi-label">Problem</h4>
+                      <p>An aging SAP Hybris 6.7 B2B platform could not support a multi-country rollout or modern headless capabilities.</p>
+                    </div>
+                    <div class="psi-block">
+                      <h4 class="psi-label">Solution</h4>
+                      <p>Led the migration to Commerce Cloud CCv2 with SAP ERP integrations for pricing, inventory and order management, plus custom OCC APIs for B2B workflows.</p>
+                    </div>
+                    <div class="psi-block">
+                      <h4 class="psi-label">Impact</h4>
+                      <p>A single B2B platform serving 15+ countries with real-time ERP data and headless commerce capabilities.</p>
+                    </div>
+                  </div>
+                </article>
+
               </div>
             </div>
           </section>
@@ -458,54 +546,6 @@
             </div>
           </section>
 
-          <section class="section" id="projects">
-            <div class="section-content">
-              <h2>Featured Integration Projects</h2>
-              <div class="projects-list">
-                
-                <div class="project-entry">
-                  <div class="project-header">
-                    <h3 class="project-title">Roche Bobois - API-Led Integration Architecture</h3>
-                    <span class="project-status">Ongoing</span>
-                  </div>
-                  <div class="project-meta">
-                    <span class="tech-tag">MuleSoft Anypoint Platform</span>
-                    <span class="tech-tag">E-Commerce Integration</span>
-                    <span class="tech-tag">Workflow Orchestration</span>
-                  </div>
-                  <p class="project-description">Building integration flows between the e-commerce platform and back-office systems using MuleSoft Anypoint Platform. Work covers API design and implementation, DataWeave transformations, error handling, and workflow orchestration across ERP, CRM, and third-party services.</p>
-                </div>
-                
-                <div class="project-entry">
-                  <div class="project-header">
-                    <h3 class="project-title">Miele - Cloud-Native Commerce Platform Migration</h3>
-                    <span class="project-status">Completed</span>
-                  </div>
-                  <div class="project-meta">
-                    <span class="tech-tag">SAP Commerce Cloud CCv2</span>
-                    <span class="tech-tag">Microservices</span>
-                    <span class="tech-tag">Kubernetes</span>
-                  </div>
-                  <p class="project-description">Contributed to migrating a global B2C e-commerce platform from on-premise SAP Hybris to Commerce Cloud (CCv2). Worked on a microservices integration layer on SAP BTP Kyma and helped optimize OCC APIs for headless commerce use cases.</p>
-                </div>
-                
-                <div class="project-entry">
-                  <div class="project-header">
-                    <h3 class="project-title">BYK - Multi-Country B2B Platform Integration</h3>
-                    <span class="project-status">Completed</span>
-                  </div>
-                  <div class="project-meta">
-                    <span class="tech-tag">SAP Commerce Cloud</span>
-                    <span class="tech-tag">ERP Integration</span>
-                    <span class="tech-tag">Multi-Site Architecture</span>
-                  </div>
-                  <p class="project-description">Led the technical implementation of a B2B e-commerce platform across 15+ countries, including migration from SAP Hybris 6.7 to CCv2. Designed integrations with SAP ERP for pricing, inventory, and order management, and built custom APIs for B2B-specific workflows.</p>
-                </div>
-                
-              </div>
-            </div>
-          </section>
-
           <section class="section" id="education">
             <div class="section-content">
               <h2>Education</h2>
@@ -609,6 +649,94 @@
             <strong>IA-augmenté & orienté futur :</strong> Utilisation quotidienne concrète de GitHub Copilot, CLI LLM Ollama, Claude et OpenAI Codex CLI — l'IA intégrée au workflow, pas seulement dans les intentions
           </div>
         </div>
+            </div>
+          </section>
+
+          <section class="section" id="projects-fr">
+            <div class="section-content">
+              <h2>Projets d'Intégration Phares</h2>
+              <div class="bento-grid" data-stagger>
+
+                <article class="project-card project-card--feature reveal">
+                  <div class="project-card-head">
+                    <span class="project-status project-status--ongoing">En cours</span>
+                    <h3 class="project-title">Roche Bobois — Architecture d'Intégration API-Led</h3>
+                    <div class="project-meta">
+                      <span class="tech-tag">MuleSoft Anypoint</span>
+                      <span class="tech-tag">DataWeave</span>
+                      <span class="tech-tag">Salesforce</span>
+                      <span class="tech-tag">Orchestration</span>
+                    </div>
+                  </div>
+                  <div class="psi">
+                    <div class="psi-block">
+                      <h4 class="psi-label">Problème</h4>
+                      <p>La plateforme e-commerce, l'ERP, le CRM et les services tiers échangeaient des données via des flux point-à-point fragmentés, difficiles à superviser et à faire évoluer.</p>
+                    </div>
+                    <div class="psi-block">
+                      <h4 class="psi-label">Solution</h4>
+                      <p>Architecture API-led sur MuleSoft Anypoint : APIs réutilisables, transformations DataWeave complexes, gestion d'erreurs robuste et patterns d'orchestration coordonnant les transactions multi-systèmes — y compris les flux de données Salesforce CRM.</p>
+                    </div>
+                    <div class="psi-block">
+                      <h4 class="psi-label">Impact</h4>
+                      <p>Un socle d'intégration unifié et observable entre commandes, CRM et ERP, avec des standards de gouvernance API adoptés par l'équipe et une livraison accélérée par les workflows augmentés par IA.</p>
+                    </div>
+                  </div>
+                </article>
+
+                <article class="project-card reveal">
+                  <div class="project-card-head">
+                    <span class="project-status">Terminé</span>
+                    <h3 class="project-title">Miele — Migration Commerce Cloud-Native</h3>
+                    <div class="project-meta">
+                      <span class="tech-tag">SAP Commerce Cloud CCv2</span>
+                      <span class="tech-tag">SAP BTP Kyma</span>
+                      <span class="tech-tag">Kubernetes</span>
+                    </div>
+                  </div>
+                  <div class="psi">
+                    <div class="psi-block">
+                      <h4 class="psi-label">Problème</h4>
+                      <p>Une plateforme B2C mondiale sur SAP Hybris on-premise limitait la scalabilité et la vélocité de déploiement.</p>
+                    </div>
+                    <div class="psi-block">
+                      <h4 class="psi-label">Solution</h4>
+                      <p>Migration zero-downtime vers SAP Commerce Cloud (CCv2), microservices sur SAP BTP Kyma, optimisation des APIs OCC et pipelines CI/CD Jenkins.</p>
+                    </div>
+                    <div class="psi-block">
+                      <h4 class="psi-label">Impact</h4>
+                      <p>Une plateforme cloud-native servant le trafic B2C mondial avec des performances, une scalabilité et un déploiement continu améliorés.</p>
+                    </div>
+                  </div>
+                </article>
+
+                <article class="project-card reveal">
+                  <div class="project-card-head">
+                    <span class="project-status">Terminé</span>
+                    <h3 class="project-title">BYK — Plateforme B2B Multi-Pays</h3>
+                    <div class="project-meta">
+                      <span class="tech-tag">SAP Commerce Cloud</span>
+                      <span class="tech-tag">SAP ERP</span>
+                      <span class="tech-tag">OCC APIs</span>
+                    </div>
+                  </div>
+                  <div class="psi">
+                    <div class="psi-block">
+                      <h4 class="psi-label">Problème</h4>
+                      <p>Une plateforme B2B vieillissante sur SAP Hybris 6.7 ne pouvait pas soutenir un déploiement multi-pays ni les capacités headless modernes.</p>
+                    </div>
+                    <div class="psi-block">
+                      <h4 class="psi-label">Solution</h4>
+                      <p>Direction de la migration vers Commerce Cloud CCv2 avec intégrations SAP ERP pour tarification, inventaire et gestion des commandes, plus des APIs OCC personnalisées pour les workflows B2B.</p>
+                    </div>
+                    <div class="psi-block">
+                      <h4 class="psi-label">Impact</h4>
+                      <p>Une plateforme B2B unique desservant 15+ pays avec des données ERP en temps réel et des capacités headless commerce.</p>
+                    </div>
+                  </div>
+                </article>
+
+              </div>
             </div>
           </section>
 
@@ -720,54 +848,6 @@
           <li>Développement d'adaptateurs d'intégration personnalisés et couches de transformation de données pour exigences spécifiques aux marques</li>
           <li>Établissement de patterns d'intégration et composants réutilisables pour futurs onboardings de marques</li>
         </ul>
-            </div>
-          </section>
-
-          <section class="section" id="projects-fr">
-            <div class="section-content">
-        <h2>Projets d'Intégration Phares</h2>
-        <div class="projects-list">
-          
-          <div class="project-entry">
-            <div class="project-header">
-              <h3 class="project-title">Roche Bobois - Architecture d'Intégration API-Led</h3>
-              <span class="project-status">En cours</span>
-            </div>
-            <div class="project-meta">
-              <span class="tech-tag">MuleSoft Anypoint Platform</span>
-              <span class="tech-tag">Intégration E-Commerce</span>
-              <span class="tech-tag">Orchestration de Workflows</span>
-            </div>
-            <p class="project-description">Construction de flux d'intégration entre la plateforme e-commerce et les systèmes back-office via MuleSoft Anypoint Platform. Le travail couvre la conception et l'implémentation d'APIs, les transformations DataWeave, la gestion d'erreurs et l'orchestration de workflows entre ERP, CRM et services tiers.</p>
-          </div>
-          
-          <div class="project-entry">
-            <div class="project-header">
-              <h3 class="project-title">Miele - Migration Plateforme Commerce Cloud-Native</h3>
-              <span class="project-status">Terminé</span>
-            </div>
-            <div class="project-meta">
-              <span class="tech-tag">SAP Commerce Cloud CCv2</span>
-              <span class="tech-tag">Microservices</span>
-              <span class="tech-tag">Kubernetes</span>
-            </div>
-            <p class="project-description">Participation à la migration d'une plateforme e-commerce B2C mondiale de SAP Hybris on-premise vers Commerce Cloud (CCv2). Contribution à une couche d'intégration microservices sur SAP BTP Kyma et amélioration des APIs OCC pour les cas d'usage headless commerce.</p>
-          </div>
-          
-          <div class="project-entry">
-            <div class="project-header">
-              <h3 class="project-title">BYK - Intégration Plateforme B2B Multi-Pays</h3>
-              <span class="project-status">Terminé</span>
-            </div>
-            <div class="project-meta">
-              <span class="tech-tag">SAP Commerce Cloud</span>
-              <span class="tech-tag">Intégration ERP</span>
-              <span class="tech-tag">Architecture Multi-Sites</span>
-            </div>
-            <p class="project-description">Direction de l'implémentation technique d'une plateforme e-commerce B2B dans 15+ pays, incluant la migration de SAP Hybris 6.7 vers CCv2. Conception des intégrations avec SAP ERP pour la tarification, l'inventaire et la gestion des commandes, et développement d'APIs personnalisées pour les workflows B2B.</p>
-          </div>
-          
-        </div>
             </div>
           </section>
 

--- a/index.html
+++ b/index.html
@@ -288,7 +288,7 @@
           <section class="section hero" id="hero">
             <div class="hero-inner">
               <div class="hero-text">
-                <p class="hero-kicker">Senior E-Commerce Integration Consultant</p>
+                <p class="hero-kicker">Senior E-Commerce Integration Consultant · MuleSoft&nbsp;·&nbsp;Applied&nbsp;AI</p>
                 <h1>Brahim Bousnguar</h1>
                 <p class="hero-tagline">I connect SAP Commerce Cloud, MuleSoft and Salesforce into integration architectures that ship.</p>
                 <p class="hero-summary">9+ years bridging enterprise e-commerce platforms with modern API-led integration — delivering end-to-end solutions for complex enterprise systems while leveraging AI-augmented workflows (GitHub Copilot, Ollama, Claude, OpenAI Codex CLI) to ship smarter and faster.</p>
@@ -596,7 +596,7 @@
           <section class="section hero" id="hero-fr">
             <div class="hero-inner">
               <div class="hero-text">
-                <p class="hero-kicker">Consultant Senior en Intégration E-Commerce</p>
+                <p class="hero-kicker">Consultant Senior en Intégration E-Commerce · MuleSoft&nbsp;·&nbsp;IA&nbsp;Appliquée</p>
                 <h1>Brahim Bousnguar</h1>
                 <p class="hero-tagline">Je connecte SAP Commerce Cloud, MuleSoft et Salesforce en architectures d'intégration qui livrent.</p>
                 <p class="hero-summary">Plus de 9 ans à relier les plateformes e-commerce d'entreprise aux architectures d'intégration API-led modernes — des solutions end-to-end pour systèmes complexes, augmentées par des workflows IA (GitHub Copilot, Ollama, Claude, OpenAI Codex CLI) pour livrer plus intelligemment et plus rapidement.</p>

--- a/index.html
+++ b/index.html
@@ -320,7 +320,7 @@
                 <span class="hero-stat-label">Years in E-Commerce</span>
               </div>
               <div class="hero-stat reveal">
-                <span class="hero-stat-number" data-count="411">411</span>
+                <span class="hero-stat-number" data-count="411" data-suffix="+">411+</span>
                 <span class="hero-stat-label">Learning Certificates</span>
               </div>
               <div class="hero-stat reveal">
@@ -469,15 +469,16 @@
               <div class="learning-journey-card">
                 <div class="learning-journey-header">
                   <div>
-                    <h2>LinkedIn Learning Certificates</h2>
-                    <p class="learning-intro">Strategic cross-domain learning across 12+ technology domains. 411 LinkedIn Learning certificates building a foundation that transcends specific technologies.</p>
+                    <h2>Continuous Learning</h2>
+                    <p class="learning-intro">An intensive cross-domain foundation: 411+ LinkedIn Learning certificates across 12+ technology domains since 2023 — and still growing.</p>
+                    <p class="learning-focus"><strong>2026 focus:</strong> agentic AI, Model Context Protocol (MCP) and AI orchestration — applied daily in production MuleSoft integration work.</p>
                   </div>
                 </div>
                 
                 <div class="learning-journey-content">
                   <div class="learning-stats-compact">
                     <div class="stat-item">
-                      <div class="stat-number-compact" id="total-certificates">411</div>
+                      <div class="stat-number-compact" id="total-certificates">411+</div>
                       <div class="stat-label-compact">Certificates</div>
                     </div>
                     <div class="stat-divider"></div>
@@ -627,7 +628,7 @@
                 <span class="hero-stat-label">Ans en E-Commerce</span>
               </div>
               <div class="hero-stat reveal">
-                <span class="hero-stat-number" data-count="411">411</span>
+                <span class="hero-stat-number" data-count="411" data-suffix="+">411+</span>
                 <span class="hero-stat-label">Certificats d'Apprentissage</span>
               </div>
               <div class="hero-stat reveal">
@@ -776,15 +777,16 @@
               <div class="learning-journey-card">
                 <div class="learning-journey-header">
                   <div>
-                    <h2>Certificats LinkedIn Learning</h2>
-                    <p class="learning-intro">Apprentissage stratégique transdisciplinaire couvrant 12+ domaines technologiques. 411 certificats LinkedIn Learning formant une fondation qui transcende les technologies spécifiques.</p>
+                    <h2>Apprentissage Continu</h2>
+                    <p class="learning-intro">Une fondation transdisciplinaire intensive : 411+ certificats LinkedIn Learning couvrant 12+ domaines technologiques depuis 2023 — et toujours en croissance.</p>
+                    <p class="learning-focus"><strong>Cap 2026 :</strong> IA agentique, Model Context Protocol (MCP) et orchestration d'IA — appliqués chaque jour dans l'intégration MuleSoft en production.</p>
                   </div>
                 </div>
                 
                 <div class="learning-journey-content">
                   <div class="learning-stats-compact">
                     <div class="stat-item">
-                      <div class="stat-number-compact">411</div>
+                      <div class="stat-number-compact">411+</div>
                       <div class="stat-label-compact">Certificats</div>
                     </div>
                     <div class="stat-divider"></div>

--- a/index.html
+++ b/index.html
@@ -57,8 +57,21 @@
   <link rel="icon" type="image/png" href="assets/img/favicon.png">
   <link rel="apple-touch-icon" sizes="180x180" href="assets/img/favicon.png">
   <meta name="theme-color" content="#0066ff">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <!-- Pre-paint theme/language restore (must stay inline to avoid flash of wrong theme) -->
+  <script>
+    (function () {
+      var theme = localStorage.getItem('theme') ||
+        (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', theme);
+      var lang = localStorage.getItem('language') || 'en';
+      document.documentElement.setAttribute('lang', lang);
+      document.documentElement.setAttribute('data-lang', lang);
+      document.documentElement.classList.add('js');
+    })();
+  </script>
   <link rel="stylesheet" href="assets/css/style.css">
+  <script src="assets/js/main.js" defer></script>
   
   <!-- JSON-LD Structured Data -->
   <script type="application/ld+json">
@@ -196,261 +209,6 @@
       }
     ]
   }
-  </script>
-  <script>
-    function switchLang(lang) {
-      document.querySelectorAll('.lang-content').forEach(el => el.classList.remove('active'));
-      document.querySelectorAll('.lang-toggle button').forEach(btn => btn.classList.remove('active'));
-      const selected = document.getElementById(lang);
-      if (selected) selected.classList.add('active');
-      const btn = document.querySelector(`.lang-toggle button[onclick*="${lang}"]`);
-      if (btn) btn.classList.add('active');
-      
-      // Update HTML lang attribute for SEO and accessibility
-      document.documentElement.setAttribute('lang', lang);
-      document.documentElement.setAttribute('data-lang', lang);
-      
-      // Save language preference to localStorage
-      localStorage.setItem('language', lang);
-
-      // Update sidebar anchors to match the active language
-      updateSidebarLang(lang);
-      
-      // Re-initialize smooth scroll and navigation for the new language content
-      if (window.initSmoothScroll) {
-        initSmoothScroll();
-      }
-      if (window.initNavigationHighlight) {
-        initNavigationHighlight();
-      }
-    }
-
-    function updateSidebarLang(lang) {
-      const suffix = lang === 'fr' ? '-fr' : '';
-      document.querySelectorAll('.sidebar-nav a[data-target]').forEach(link => {
-        const base = link.getAttribute('data-target');
-        link.setAttribute('href', `#${base}${suffix}`);
-      });
-    }
-    
-    function toggleTheme() {
-      const currentTheme = document.documentElement.getAttribute('data-theme');
-      const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-      
-      document.documentElement.setAttribute('data-theme', newTheme);
-      localStorage.setItem('theme', newTheme);
-      
-      // Update toggle button
-      const lightOption = document.getElementById('light-option');
-      const darkOption = document.getElementById('dark-option');
-      
-      if (newTheme === 'light') {
-        lightOption.classList.add('active');
-        darkOption.classList.remove('active');
-      } else {
-        darkOption.classList.add('active');
-        lightOption.classList.remove('active');
-      }
-    }
-    
-    window.onload = function () {
-      // Load saved language preference or default to English
-      const savedLang = localStorage.getItem('language') || 'en';
-      switchLang(savedLang);
-      
-      // Ensure HTML lang attribute is set on initial load
-      document.documentElement.setAttribute('lang', savedLang);
-      
-      // Detect system theme preference
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      const savedTheme = localStorage.getItem('theme');
-      
-      // Use saved theme if available, otherwise use system preference (default to light)
-      const defaultTheme = savedTheme || (prefersDark ? 'dark' : 'light');
-      
-      document.documentElement.setAttribute('data-theme', defaultTheme);
-      
-      // Update toggle button based on theme
-      const lightOption = document.getElementById('light-option');
-      const darkOption = document.getElementById('dark-option');
-      
-      if (defaultTheme === 'light') {
-        lightOption.classList.add('active');
-        darkOption.classList.remove('active');
-      } else {
-        darkOption.classList.add('active');
-        lightOption.classList.remove('active');
-      }
-      
-      // Listen for system theme changes
-      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-        if (!localStorage.getItem('theme')) { // Only auto-switch if user hasn't set a preference
-          const newTheme = e.matches ? 'dark' : 'light';
-          document.documentElement.setAttribute('data-theme', newTheme);
-          
-          if (newTheme === 'light') {
-            lightOption.classList.add('active');
-            darkOption.classList.remove('active');
-          } else {
-            darkOption.classList.add('active');
-            lightOption.classList.remove('active');
-          }
-        }
-      });
-      
-      // Back to top button functionality
-      initBackToTop();
-      
-      // Smooth scroll for anchor links
-      initSmoothScroll();
-      
-      // Navigation active state on scroll
-      initNavigationHighlight();
-    };
-    
-    function initNavigationHighlight() {
-      // Get only sections from the currently active language content
-      const activeContent = document.querySelector('.lang-content.active');
-      if (!activeContent) return;
-      
-      const navLinks = document.querySelectorAll('.sidebar-nav a[href^="#"]');
-      
-      // Track if user just clicked a link
-      window.navigationClickTime = 0;
-      
-      window.updateActiveNavLink = function(targetId) {
-        navLinks.forEach(link => {
-          link.classList.remove('active');
-          if (link.getAttribute('href') === targetId) {
-            link.classList.add('active');
-          }
-        });
-      };
-      
-      // Remove old scroll listener if exists
-      if (window.scrollHighlightHandler) {
-        window.removeEventListener('scroll', window.scrollHighlightHandler);
-      }
-      
-      // Create new scroll handler that always checks current active content
-      window.scrollHighlightHandler = function() {
-        // Don't update highlighting for 800ms after a click
-        if (Date.now() - window.navigationClickTime < 800) {
-          return;
-        }
-        
-        const currentActiveContent = document.querySelector('.lang-content.active');
-        if (!currentActiveContent) return;
-        
-        const currentSections = currentActiveContent.querySelectorAll('.section[id]');
-        const scrollPosition = window.scrollY + 200; // Check what's near top of viewport
-        
-        let currentSection = '';
-        
-        currentSections.forEach(section => {
-          const rect = section.getBoundingClientRect();
-          const sectionTop = rect.top + window.scrollY;
-          const sectionBottom = sectionTop + rect.height;
-          
-          // Check if the scroll position is within this section
-          if (scrollPosition >= sectionTop && scrollPosition <= sectionBottom) {
-            currentSection = '#' + section.id;
-          }
-        });
-        
-        if (currentSection && window.updateActiveNavLink) {
-          updateActiveNavLink(currentSection);
-        }
-      };
-      
-      // Add the new scroll listener with throttling
-      let isScrolling = false;
-      window.addEventListener('scroll', () => {
-        if (!isScrolling) {
-          window.requestAnimationFrame(() => {
-            if (window.scrollHighlightHandler) {
-              window.scrollHighlightHandler();
-            }
-            isScrolling = false;
-          });
-        }
-        isScrolling = true;
-      });
-      
-      // Trigger initial highlight check
-      if (window.scrollHighlightHandler) {
-        setTimeout(() => window.scrollHighlightHandler(), 100);
-      }
-    }
-    
-    function initBackToTop() {
-      // Create back to top button
-      const backToTop = document.createElement('button');
-      backToTop.className = 'back-to-top';
-      backToTop.innerHTML = '↑';
-      backToTop.setAttribute('aria-label', 'Back to top');
-      backToTop.title = 'Back to top';
-      document.body.appendChild(backToTop);
-      
-      // Show/hide on scroll
-      window.addEventListener('scroll', () => {
-        if (window.pageYOffset > 300) {
-          backToTop.classList.add('visible');
-        } else {
-          backToTop.classList.remove('visible');
-        }
-      });
-      
-      // Scroll to top on click
-      backToTop.addEventListener('click', () => {
-        window.scrollTo({
-          top: 0,
-          behavior: 'smooth'
-        });
-      });
-    }
-    
-    function initSmoothScroll() {
-      // Remove old listeners by cloning and replacing navigation links
-      const navLinks = document.querySelectorAll('.sidebar-nav a[href^="#"]');
-      navLinks.forEach(link => {
-        const newLink = link.cloneNode(true);
-        link.parentNode.replaceChild(newLink, link);
-      });
-      
-      // Add fresh event listeners
-      document.querySelectorAll('.sidebar-nav a[href^="#"]').forEach(anchor => {
-        anchor.addEventListener('click', function (e) {
-          e.preventDefault();
-          const targetId = this.getAttribute('href');
-          
-          // Update click timestamp to prevent scroll handler from overriding
-          window.navigationClickTime = Date.now();
-          
-          // Find target in active language content
-          const activeContent = document.querySelector('.lang-content.active');
-          if (!activeContent) return;
-          
-          const target = activeContent.querySelector(targetId);
-          if (target) {
-            // Calculate offset for sticky header (approx 60px) + extra spacing
-            const headerOffset = 80;
-            const elementPosition = target.getBoundingClientRect().top;
-            const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
-            
-            window.scrollTo({
-              top: offsetPosition,
-              behavior: 'smooth'
-            });
-            
-            // Update active state immediately on click
-            if (window.updateActiveNavLink) {
-              updateActiveNavLink(targetId);
-            }
-          }
-        });
-      });
-    }
   </script>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@
     <!-- Sidebar Navigation -->
     <aside class="sidebar">
       <ul class="sidebar-nav">
-        <li><a href="#summary" data-target="summary" class="active">Summary</a></li>
+        <li><a href="#hero" data-target="hero" class="active">Overview</a></li>
         <li><a href="#value-proposition" data-target="value-proposition">Value Proposition</a></li>
         <li><a href="#skills" data-target="skills">Skills</a></li>
         <li><a href="#certifications" data-target="certifications">Certifications</a></li>
@@ -280,35 +280,54 @@
           <span>CV</span>
         </nav>
 
-        <!-- Quick Links -->
-        <div class="nav-links">
-          <a href="docs/Brahim_Bousnguar_CV.pdf" target="_blank" rel="noopener noreferrer" class="nav-link-primary">
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <path d="M14 9V14C14 14.5523 13.5523 15 13 15H3C2.44772 15 2 14.5523 2 14V9M5 7L8 10M8 10L11 7M8 10V2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-            Download CV
-          </a>
-          <a href="https://github.com/brbousnguar" target="_blank" rel="noopener noreferrer" class="nav-link-secondary">GitHub</a>
-          <a href="https://www.linkedin.com/in/brahim-bousnguar/" target="_blank" rel="noopener noreferrer" class="nav-link-secondary">LinkedIn</a>
-        </div>
-
         <div id="en" class="lang-content">
-          <!-- Professional Header -->
-          <section class="professional-header">
-            <div class="header-left">
-              <img src="assets/img/profile.jpeg" alt="Brahim Bousnguar - Senior E-Commerce Integration Consultant" width="100" height="100" class="profile-img" loading="eager">
+          <!-- Hero -->
+          <section class="section hero" id="hero">
+            <div class="hero-inner">
+              <div class="hero-text">
+                <p class="hero-kicker">Senior E-Commerce Integration Consultant</p>
+                <h1>Brahim Bousnguar</h1>
+                <p class="hero-tagline">I connect SAP Commerce Cloud, MuleSoft and Salesforce into integration architectures that ship.</p>
+                <p class="hero-summary">9+ years bridging enterprise e-commerce platforms with modern API-led integration — delivering end-to-end solutions for complex enterprise systems while leveraging AI-augmented workflows (GitHub Copilot, Ollama, Claude, OpenAI Codex CLI) to ship smarter and faster.</p>
+                <div class="hero-actions">
+                  <a href="#projects" class="btn-primary hero-cta">View Projects</a>
+                  <a href="docs/Brahim_Bousnguar_CV.pdf" target="_blank" rel="noopener noreferrer" class="btn-secondary hero-cta">
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                      <path d="M14 9V14C14 14.5523 13.5523 15 13 15H3C2.44772 15 2 14.5523 2 14V9M5 7L8 10M8 10L11 7M8 10V2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                    Download CV
+                  </a>
+                </div>
+                <div class="hero-social">
+                  <a href="https://github.com/brbousnguar" target="_blank" rel="noopener noreferrer">GitHub</a>
+                  <span class="hero-social-sep" aria-hidden="true">·</span>
+                  <a href="https://www.linkedin.com/in/brahim-bousnguar/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+                </div>
+              </div>
+              <div class="hero-portrait">
+                <div class="hero-portrait-card">
+                  <img src="assets/img/profile.jpeg" alt="Brahim Bousnguar - Senior E-Commerce Integration Consultant" width="180" height="180" class="hero-img" loading="eager">
+                  <p class="hero-portrait-caption">SAP Commerce Cloud · MuleSoft · Salesforce</p>
+                </div>
+              </div>
             </div>
-            <div class="header-content">
-              <h1>Brahim BOUSNGUAR</h1>
-              <p class="title-line">Senior E-Commerce Integration Consultant</p>
-              <p class="experience-line">9+ years · SAP Commerce Cloud · MuleSoft · Salesforce · AI-Augmented Development</p>
-            </div>
-          </section>
-
-          <section class="section" id="summary">
-            <div class="section-content">
-              <h2>Summary</h2>
-              <p>Senior E-Commerce Integration Consultant with 9+ years of expertise bridging enterprise e-commerce platforms with modern API-led integration architectures. Specialized in SAP Commerce Cloud (formerly Hybris) and MuleSoft Anypoint Platform, with proven confidence in Salesforce ecosystem integrations. Delivers end-to-end solutions for complex enterprise systems while actively leveraging AI-augmented development workflows — GitHub Copilot, Ollama-powered CLI automation, Claude, and OpenAI Codex CLI — to ship smarter and faster.</p>
+            <div class="hero-stats" data-stagger>
+              <div class="hero-stat reveal">
+                <span class="hero-stat-number" data-count="9" data-suffix="+">9+</span>
+                <span class="hero-stat-label">Years in E-Commerce</span>
+              </div>
+              <div class="hero-stat reveal">
+                <span class="hero-stat-number" data-count="411">411</span>
+                <span class="hero-stat-label">Learning Certificates</span>
+              </div>
+              <div class="hero-stat reveal">
+                <span class="hero-stat-number" data-count="15" data-suffix="+">15+</span>
+                <span class="hero-stat-label">Countries Served</span>
+              </div>
+              <div class="hero-stat reveal">
+                <span class="hero-stat-number" data-count="4">4</span>
+                <span class="hero-stat-label">Enterprise Clients</span>
+              </div>
             </div>
           </section>
 
@@ -528,22 +547,53 @@
         </div>
 
         <div id="fr" class="lang-content">
-          <!-- Professional Header -->
-          <section class="professional-header">
-            <div class="header-left">
-              <img src="assets/img/profile.jpeg" alt="Brahim Bousnguar - Senior E-Commerce Integration Consultant" width="100" height="100" class="profile-img" loading="eager">
+          <!-- Hero -->
+          <section class="section hero" id="hero-fr">
+            <div class="hero-inner">
+              <div class="hero-text">
+                <p class="hero-kicker">Consultant Senior en Intégration E-Commerce</p>
+                <h1>Brahim Bousnguar</h1>
+                <p class="hero-tagline">Je connecte SAP Commerce Cloud, MuleSoft et Salesforce en architectures d'intégration qui livrent.</p>
+                <p class="hero-summary">Plus de 9 ans à relier les plateformes e-commerce d'entreprise aux architectures d'intégration API-led modernes — des solutions end-to-end pour systèmes complexes, augmentées par des workflows IA (GitHub Copilot, Ollama, Claude, OpenAI Codex CLI) pour livrer plus intelligemment et plus rapidement.</p>
+                <div class="hero-actions">
+                  <a href="#projects-fr" class="btn-primary hero-cta">Voir les Projets</a>
+                  <a href="docs/Brahim_Bousnguar_CV.pdf" target="_blank" rel="noopener noreferrer" class="btn-secondary hero-cta">
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                      <path d="M14 9V14C14 14.5523 13.5523 15 13 15H3C2.44772 15 2 14.5523 2 14V9M5 7L8 10M8 10L11 7M8 10V2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                    Télécharger le CV
+                  </a>
+                </div>
+                <div class="hero-social">
+                  <a href="https://github.com/brbousnguar" target="_blank" rel="noopener noreferrer">GitHub</a>
+                  <span class="hero-social-sep" aria-hidden="true">·</span>
+                  <a href="https://www.linkedin.com/in/brahim-bousnguar/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+                </div>
+              </div>
+              <div class="hero-portrait">
+                <div class="hero-portrait-card">
+                  <img src="assets/img/profile.jpeg" alt="Brahim Bousnguar - Consultant Senior en Intégration E-Commerce" width="180" height="180" class="hero-img" loading="eager">
+                  <p class="hero-portrait-caption">SAP Commerce Cloud · MuleSoft · Salesforce</p>
+                </div>
+              </div>
             </div>
-            <div class="header-content">
-              <h1>Brahim BOUSNGUAR</h1>
-              <p class="title-line">Consultant Senior en Intégration E-Commerce</p>
-              <p class="experience-line">9+ ans · SAP Commerce Cloud · MuleSoft · Salesforce · Développement Augmenté IA</p>
-            </div>
-          </section>
-
-          <section class="section" id="summary-fr">
-            <div class="section-content">
-              <h2>Résumé</h2>
-              <p>Consultant Senior en Intégration E-Commerce avec plus de 9 ans d'expertise en conception de solutions reliant les plateformes e-commerce d'entreprise aux architectures d'intégration modernes basées sur les APIs. Spécialisé en SAP Commerce Cloud (anciennement Hybris) et MuleSoft Anypoint Platform, avec une maîtrise confirmée de l'écosystème Salesforce. Livre des solutions end-to-end pour systèmes d'entreprise complexes tout en intégrant activement des workflows de développement augmentés par IA — GitHub Copilot, automatisation CLI Ollama, Claude et OpenAI Codex CLI — pour livrer plus intelligemment et plus rapidement.</p>
+            <div class="hero-stats" data-stagger>
+              <div class="hero-stat reveal">
+                <span class="hero-stat-number" data-count="9" data-suffix="+">9+</span>
+                <span class="hero-stat-label">Ans en E-Commerce</span>
+              </div>
+              <div class="hero-stat reveal">
+                <span class="hero-stat-number" data-count="411">411</span>
+                <span class="hero-stat-label">Certificats d'Apprentissage</span>
+              </div>
+              <div class="hero-stat reveal">
+                <span class="hero-stat-number" data-count="15" data-suffix="+">15+</span>
+                <span class="hero-stat-label">Pays Desservis</span>
+              </div>
+              <div class="hero-stat reveal">
+                <span class="hero-stat-number" data-count="4">4</span>
+                <span class="hero-stat-label">Clients Grands Comptes</span>
+              </div>
             </div>
           </section>
 

--- a/index.html
+++ b/index.html
@@ -36,6 +36,9 @@
   
   <!-- Canonical URL -->
   <link rel="canonical" href="https://brbousnguar.github.io/">
+
+  <!-- Machine-readable profile for AI agents and integrations -->
+  <link rel="alternate" type="application/json" href="/profile.json" title="Structured profile (JSON Resume)">
   
   <!-- Hreflang tags for multilingual SEO -->
   <link rel="alternate" hreflang="en" href="https://brbousnguar.github.io/">
@@ -467,14 +470,14 @@
                 <div class="learning-journey-header">
                   <div>
                     <h2>LinkedIn Learning Certificates</h2>
-                    <p class="learning-intro">Strategic cross-domain learning across 12+ technology domains. 409 LinkedIn Learning certificates building a foundation that transcends specific technologies.</p>
+                    <p class="learning-intro">Strategic cross-domain learning across 12+ technology domains. 411 LinkedIn Learning certificates building a foundation that transcends specific technologies.</p>
                   </div>
                 </div>
                 
                 <div class="learning-journey-content">
                   <div class="learning-stats-compact">
                     <div class="stat-item">
-                      <div class="stat-number-compact" id="total-certificates">409</div>
+                      <div class="stat-number-compact" id="total-certificates">411</div>
                       <div class="stat-label-compact">Certificates</div>
                     </div>
                     <div class="stat-divider"></div>
@@ -774,14 +777,14 @@
                 <div class="learning-journey-header">
                   <div>
                     <h2>Certificats LinkedIn Learning</h2>
-                    <p class="learning-intro">Apprentissage stratégique transdisciplinaire couvrant 12+ domaines technologiques. 409 certificats LinkedIn Learning formant une fondation qui transcende les technologies spécifiques.</p>
+                    <p class="learning-intro">Apprentissage stratégique transdisciplinaire couvrant 12+ domaines technologiques. 411 certificats LinkedIn Learning formant une fondation qui transcende les technologies spécifiques.</p>
                   </div>
                 </div>
                 
                 <div class="learning-journey-content">
                   <div class="learning-stats-compact">
                     <div class="stat-item">
-                      <div class="stat-number-compact">409</div>
+                      <div class="stat-number-compact">411</div>
                       <div class="stat-label-compact">Certificats</div>
                     </div>
                     <div class="stat-divider"></div>

--- a/index.html
+++ b/index.html
@@ -331,7 +331,7 @@
             </div>
           </section>
 
-          <section class="section" id="value-proposition">
+          <section class="section reveal" id="value-proposition">
             <div class="section-content">
               <h2>Unique Value Proposition</h2>
               <p>I bridge the gap between e-commerce platforms and modern integration architectures. My combination of deep SAP Commerce Cloud expertise (9+ years), production-grade MuleSoft Anypoint proficiency, and growing Salesforce ecosystem confidence enables me to design and deliver comprehensive integration solutions — while actively applying AI tooling to accelerate delivery and raise quality.</p>
@@ -346,7 +346,7 @@
             </div>
           </section>
 
-          <section class="section" id="projects">
+          <section class="section reveal" id="projects">
             <div class="section-content">
               <h2>Featured Integration Projects</h2>
               <div class="bento-grid" data-stagger>
@@ -434,7 +434,7 @@
             </div>
           </section>
 
-          <section class="section" id="skills">
+          <section class="section reveal" id="skills">
             <div class="section-content">
               <h2>Technical Skills</h2>
               <ul>
@@ -450,18 +450,18 @@
             </div>
           </section>
 
-          <section class="section" id="certifications">
+          <section class="section reveal" id="certifications">
             <div class="section-content">
               <h2>Professional Certifications</h2>
               <ul>
                 <li>SAP Certified Development Professional - SAP Commerce Cloud Developer (2023)</li>
                 <li>SAP Certified Associate - SAP Hybris Commerce Business Analyst 6.3 (2018)</li>
               </ul>
-              <p style="margin-top: 1rem; color: var(--text-muted); font-style: italic;">Currently pursuing MuleSoft Anypoint Platform certifications</p>
+              <p class="note-muted">Currently pursuing MuleSoft Anypoint Platform certifications</p>
             </div>
           </section>
 
-          <section class="section" id="continuous-learning">
+          <section class="section reveal" id="continuous-learning">
             <div class="section-content">
               <div class="learning-journey-card">
                 <div class="learning-journey-header">
@@ -495,7 +495,7 @@
             </div>
           </section>
 
-          <section class="section" id="professional-experience">
+          <section class="section reveal" id="professional-experience">
             <div class="section-content">
               <h2>Professional Experience</h2>
         
@@ -546,7 +546,7 @@
             </div>
           </section>
 
-          <section class="section" id="education">
+          <section class="section reveal" id="education">
             <div class="section-content">
               <h2>Education</h2>
               <p>2015 - State Engineer in Computer Science & BI, INSEA Rabat</p>
@@ -554,23 +554,23 @@
           </section>
           
           <!-- FAQ Section for AI SEO -->
-          <section class="section" id="faq">
+          <section class="section reveal" id="faq">
             <div class="section-content">
               <h2>Frequently Asked Questions</h2>
-              <div class="faq-grid">
-                <div class="faq-item">
+              <div class="faq-grid" data-stagger>
+                <div class="faq-item reveal">
                   <h3 class="faq-question">What makes you different from other SAP Commerce consultants?</h3>
                   <p class="faq-answer">My background covers the full integration stack: SAP Commerce Cloud for e-commerce (9+ years), MuleSoft Anypoint for API-led connectivity, and Salesforce for CRM integration. I also apply AI tooling concretely in my daily work — GitHub Copilot, Ollama, Claude, and OpenAI Codex CLI — which helps with things like automating commit and PR generation from code diffs.</p>
                 </div>
-                <div class="faq-item">
+                <div class="faq-item reveal">
                   <h3 class="faq-question">What types of projects do you specialize in?</h3>
                   <p class="faq-answer">I specialize in cloud-native e-commerce migrations (CCv2), API-led integration architecture, microservices implementation on Kubernetes, multi-country B2B/B2C platform development, and complex ERP/CRM integrations using MuleSoft Anypoint Platform.</p>
                 </div>
-                <div class="faq-item">
+                <div class="faq-item reveal">
                   <h3 class="faq-question">Do you work with remote teams?</h3>
                   <p class="faq-answer">Yes, I have extensive experience working with distributed teams across Europe. I'm proficient in agile methodologies, remote collaboration tools, and can effectively lead or contribute to international projects.</p>
                 </div>
-                <div class="faq-item">
+                <div class="faq-item reveal">
                   <h3 class="faq-question">What is your approach to integration architecture?</h3>
                   <p class="faq-answer">I follow API-led connectivity principles with clear separation of System, Process, and Experience layers. I prioritize reusable APIs, proper error handling, comprehensive monitoring, and governance frameworks that scale with business growth.</p>
                 </div>
@@ -578,10 +578,11 @@
             </div>
           </section>
 
-          <section class="section" id="contact">
-            <div class="section-content">
-              <h2>Contact</h2>
-              <p>Email: <a href="mailto:b.bousnguar@gmail.com" class="contact-email" aria-label="Contact Brahim Bousnguar by email">b.bousnguar@gmail.com</a></p>
+          <section class="section reveal" id="contact">
+            <div class="section-content contact-cta">
+              <h2>Let's Work Together</h2>
+              <p>Open to consulting engagements in SAP Commerce Cloud, MuleSoft and Salesforce integration — let's discuss your next e-commerce or integration challenge.</p>
+              <a href="mailto:b.bousnguar@gmail.com" class="btn-primary" aria-label="Contact Brahim Bousnguar by email">b.bousnguar@gmail.com</a>
             </div>
           </section>
         </div>
@@ -637,7 +638,7 @@
             </div>
           </section>
 
-          <section class="section" id="value-proposition-fr">
+          <section class="section reveal" id="value-proposition-fr">
             <div class="section-content">
               <h2>Proposition de Valeur Unique</h2>
         <p>Je fais le pont entre les plateformes e-commerce et les architectures d'intégration modernes. Ma combinaison d'expertise approfondie en SAP Commerce Cloud (9+ ans), de maîtrise avérée de MuleSoft Anypoint et de confiance grandissante dans l'écosystème Salesforce me permet de concevoir et livrer des solutions d'intégration complètes — tout en appliquant concrètement les outils IA pour accélérer la livraison et élever la qualité.</p>
@@ -652,7 +653,7 @@
             </div>
           </section>
 
-          <section class="section" id="projects-fr">
+          <section class="section reveal" id="projects-fr">
             <div class="section-content">
               <h2>Projets d'Intégration Phares</h2>
               <div class="bento-grid" data-stagger>
@@ -740,7 +741,7 @@
             </div>
           </section>
 
-          <section class="section" id="skills-fr">
+          <section class="section reveal" id="skills-fr">
             <div class="section-content">
               <h2>Compétences Techniques</h2>
         <ul>
@@ -756,18 +757,18 @@
             </div>
           </section>
 
-          <section class="section" id="certifications-fr">
+          <section class="section reveal" id="certifications-fr">
             <div class="section-content">
               <h2>Certifications Professionnelles</h2>
         <ul>
           <li>Certifié SAP Commerce Cloud Developer (2023)</li>
           <li>Certifié SAP Hybris Business Analyst 6.3 (2018)</li>
         </ul>
-        <p style="margin-top: 1rem; color: var(--text-muted); font-style: italic;">Actuellement en cours de certification MuleSoft Anypoint Platform</p>
+        <p class="note-muted">Actuellement en cours de certification MuleSoft Anypoint Platform</p>
             </div>
           </section>
 
-          <section class="section" id="continuous-learning-fr">
+          <section class="section reveal" id="continuous-learning-fr">
             <div class="section-content">
               <div class="learning-journey-card">
                 <div class="learning-journey-header">
@@ -801,7 +802,7 @@
             </div>
           </section>
 
-          <section class="section" id="professional-experience-fr">
+          <section class="section reveal" id="professional-experience-fr">
             <div class="section-content">
               <h2>Expériences Professionnelles</h2>
 
@@ -851,7 +852,7 @@
             </div>
           </section>
 
-          <section class="section" id="education-fr">
+          <section class="section reveal" id="education-fr">
             <div class="section-content">
               <h2>Formation</h2>
               <p>2015 - Ingénieur d'État en Informatique & BI, INSEA Rabat</p>
@@ -859,23 +860,23 @@
           </section>
           
           <!-- FAQ Section for AI SEO -->
-          <section class="section" id="faq-fr">
+          <section class="section reveal" id="faq-fr">
             <div class="section-content">
               <h2>Questions Fréquentes</h2>
-              <div class="faq-grid">
-                <div class="faq-item">
+              <div class="faq-grid" data-stagger>
+                <div class="faq-item reveal">
                   <h3 class="faq-question">Qu'est-ce qui vous différencie des autres consultants SAP Commerce ?</h3>
                   <p class="faq-answer">Mon expérience couvre l'ensemble du spectre de l'intégration : SAP Commerce Cloud pour l'e-commerce (9+ ans), MuleSoft Anypoint pour la connectivité API-led, et Salesforce pour l'intégration CRM. J'applique également des outils IA concrètement dans mon travail quotidien — GitHub Copilot, Ollama, Claude et OpenAI Codex CLI — notamment pour automatiser la génération de commits et pull requests à partir de diffs de code.</p>
                 </div>
-                <div class="faq-item">
+                <div class="faq-item reveal">
                   <h3 class="faq-question">Dans quels types de projets vous spécialisez-vous ?</h3>
                   <p class="faq-answer">Je me spécialise dans les migrations e-commerce cloud-native (CCv2), l'architecture d'intégration API-led, l'implémentation de microservices sur Kubernetes, le développement de plateformes B2B/B2C multi-pays, et les intégrations complexes ERP/CRM avec MuleSoft Anypoint Platform.</p>
                 </div>
-                <div class="faq-item">
+                <div class="faq-item reveal">
                   <h3 class="faq-question">Travaillez-vous avec des équipes distantes ?</h3>
                   <p class="faq-answer">Oui, j'ai une vaste expérience de travail avec des équipes distribuées à travers l'Europe. Je maîtrise les méthodologies agiles, les outils de collaboration à distance, et peux efficacement diriger ou contribuer à des projets internationaux.</p>
                 </div>
-                <div class="faq-item">
+                <div class="faq-item reveal">
                   <h3 class="faq-question">Quelle est votre approche de l'architecture d'intégration ?</h3>
                   <p class="faq-answer">Je suis les principes d'API-led connectivity avec une séparation claire des couches System, Process et Experience. Je privilégie les APIs réutilisables, une gestion d'erreurs appropriée, un monitoring complet, et des frameworks de gouvernance qui évoluent avec la croissance business.</p>
                 </div>
@@ -883,10 +884,11 @@
             </div>
           </section>
 
-          <section class="section" id="contact-fr">
-            <div class="section-content">
-              <h2>Contact</h2>
-              <p>Email: <a href="mailto:b.bousnguar@gmail.com" class="contact-email" aria-label="Contacter Brahim Bousnguar par email">b.bousnguar@gmail.com</a></p>
+          <section class="section reveal" id="contact-fr">
+            <div class="section-content contact-cta">
+              <h2>Travaillons Ensemble</h2>
+              <p>Disponible pour des missions de conseil en intégration SAP Commerce Cloud, MuleSoft et Salesforce — discutons de votre prochain défi e-commerce ou d'intégration.</p>
+              <a href="mailto:b.bousnguar@gmail.com" class="btn-primary" aria-label="Contacter Brahim Bousnguar par email">b.bousnguar@gmail.com</a>
             </div>
           </section>
         </div>

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@ Key facts:
 - Current role: MuleSoft Integration Specialist at Roche Bobois (since January 2025) — API-led integration architecture, DataWeave, Salesforce CRM data flows.
 - Previous: Senior SAP Commerce Cloud Consultant at Miele (2022–2024, cloud-native CCv2 migration + SAP BTP Kyma microservices); Technical Lead at BYK (2018–2021, multi-country B2B platform, Hybris 6.7 → CCv2); SAP Hybris Integration Specialist at SEB Group (2016–2018, multi-brand platform).
 - Certifications: SAP Certified Development Professional — SAP Commerce Cloud Developer (2023); SAP Certified Associate — Hybris Commerce Business Analyst 6.3 (2018). Currently pursuing MuleSoft Anypoint Platform certifications.
-- Continuous learning: 411 LinkedIn Learning certificates across 11 technology domains (AI, programming, cloud, DevOps, APIs, and more), 2023–2026.
+- Continuous learning: 411+ LinkedIn Learning certificates across 11 technology domains (AI, programming, cloud, DevOps, APIs, and more) since 2023, and still growing. Current 2026 focus: agentic AI, Model Context Protocol (MCP), and AI orchestration.
 - AI-augmented workflow: daily use of GitHub Copilot, Ollama-based LLM CLI tooling, Claude, and OpenAI Codex CLI.
 - Education: State Engineer in Computer Science & Business Intelligence, INSEA Rabat (2015).
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,30 @@
+# Brahim Bousnguar
+
+> Senior E-Commerce Integration Consultant with 9+ years of experience specializing in SAP Commerce Cloud (Hybris/CCv2), MuleSoft Anypoint Platform, and Salesforce integration. Based in France, working with enterprise clients across 15+ countries. Bilingual English/French.
+
+Key facts:
+
+- Current role: MuleSoft Integration Specialist at Roche Bobois (since January 2025) — API-led integration architecture, DataWeave, Salesforce CRM data flows.
+- Previous: Senior SAP Commerce Cloud Consultant at Miele (2022–2024, cloud-native CCv2 migration + SAP BTP Kyma microservices); Technical Lead at BYK (2018–2021, multi-country B2B platform, Hybris 6.7 → CCv2); SAP Hybris Integration Specialist at SEB Group (2016–2018, multi-brand platform).
+- Certifications: SAP Certified Development Professional — SAP Commerce Cloud Developer (2023); SAP Certified Associate — Hybris Commerce Business Analyst 6.3 (2018). Currently pursuing MuleSoft Anypoint Platform certifications.
+- Continuous learning: 411 LinkedIn Learning certificates across 11 technology domains (AI, programming, cloud, DevOps, APIs, and more), 2023–2026.
+- AI-augmented workflow: daily use of GitHub Copilot, Ollama-based LLM CLI tooling, Claude, and OpenAI Codex CLI.
+- Education: State Engineer in Computer Science & Business Intelligence, INSEA Rabat (2015).
+
+## Pages
+
+- [Portfolio home](https://brbousnguar.github.io/): hero, value proposition, project case studies (Problem/Solution/Impact), skills, experience, FAQ, contact. English and French content both present in the page.
+- [About](https://brbousnguar.github.io/pages/about.html): extended professional story, career timeline, detailed skills tables.
+- [Learning & certifications](https://brbousnguar.github.io/pages/learning.html): browsable catalog of all 411 LinkedIn Learning certificates with filtering by domain, year, and skill.
+
+## Machine-readable
+
+- [profile.json](https://brbousnguar.github.io/profile.json): JSON Resume-style structured profile (basics, work history, skills, projects, education).
+- [learning-data.json](https://brbousnguar.github.io/assets/data/learning-data.json): full certificate dataset (411 entries with title, date, duration, domain, skills).
+- [CV PDF](https://brbousnguar.github.io/docs/Brahim_Bousnguar_CV.pdf): downloadable résumé.
+
+## Contact
+
+- Email: b.bousnguar@gmail.com
+- LinkedIn: https://www.linkedin.com/in/brahim-bousnguar/
+- GitHub: https://github.com/brbousnguar

--- a/pages/about.html
+++ b/pages/about.html
@@ -124,7 +124,7 @@
     <!-- Sidebar Navigation -->
     <aside class="sidebar">
       <ul class="sidebar-nav">
-        <li><a href="../index.html#summary">Summary</a></li>
+        <li><a href="../index.html#hero">Overview</a></li>
         <li><a href="../index.html#value-proposition">Value</a></li>
         <li><a href="../index.html#professional-experience">Experience</a></li>
         <li><a href="../index.html#projects">Projects</a></li>

--- a/pages/about.html
+++ b/pages/about.html
@@ -42,7 +42,8 @@
   
   <link rel="icon" type="image/png" href="../assets/img/favicon.png">
   <link rel="apple-touch-icon" sizes="180x180" href="../assets/img/favicon.png">
-  <meta name="theme-color" content="#0066ff">
+  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#faf9f7">
+  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#121110">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <!-- Pre-paint theme/language restore (must stay inline to avoid flash of wrong theme) -->
   <script>

--- a/pages/about.html
+++ b/pages/about.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en" data-lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -170,7 +170,7 @@
             <path d="M30,0 v30 M0,15 h60" stroke="#C8102E" stroke-width="6"/></g>
           </svg>
         </button>
-        <button onclick="switchLang('fr')" aria-label="Switch to French" title="FranÃ§ais">
+        <button onclick="switchLang('fr')" aria-label="Switch to French" title="Français">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" width="24" height="16">
             <rect width="900" height="600" fill="#ED2939"/>
             <rect width="600" height="600" fill="#fff"/>
@@ -179,8 +179,8 @@
         </button>
       </div>
       <div class="theme-toggle" onclick="toggleTheme()">
-        <button class="theme-toggle-option" id="light-option" aria-label="Light mode">â˜€ï¸</button>
-        <button class="theme-toggle-option" id="dark-option" aria-label="Dark mode">ðŸŒ™</button>
+        <button class="theme-toggle-option" id="light-option" aria-label="Light mode">☀️</button>
+        <button class="theme-toggle-option" id="dark-option" aria-label="Dark mode">🌙</button>
       </div>
     </div>
   </header>
@@ -208,9 +208,12 @@
         <!-- Breadcrumb -->
         <nav class="breadcrumb" aria-label="Breadcrumb">
           <a href="../index.html">Home</a>
-          <span class="separator" aria-hidden="true">â€º</span>
+          <span class="separator" aria-hidden="true">›</span>
           <span>About Me</span>
         </nav>
+
+        <div id="en" class="lang-content">
+          <h1>About Me</h1>
           <p style="font-size: 1.125rem; color: var(--text-secondary); margin-bottom: 2rem; font-weight: 400;">
             My journey from a fresh engineering graduate to a Senior E-Commerce Integration Consultant bridging traditional platforms with modern API-led architectures.
           </p>
@@ -281,7 +284,7 @@
             I'm a lifelong learner who thrives on staying current with emerging technologies. Whether it's mastering API-led connectivity principles, implementing cloud-native architectures, or optimizing system performance, I love diving deep into technical challenges and sharing knowledge with my team.
           </p>
           <p>
-            Beyond integration platforms, I've embraced AI-augmented development as a core part of my practice. I use GitHub Copilot for day-to-day code acceleration, a custom CLI script powered by Ollama that generates commit messages and pull request descriptions from code diffs using local and cloud LLMs, and tools like Claude and OpenAI Codex CLI for intelligent code review and generation. This isn't about following a trend â€” it's a concrete investment in shipping better quality work, faster.
+            Beyond integration platforms, I've embraced AI-augmented development as a core part of my practice. I use GitHub Copilot for day-to-day code acceleration, a custom CLI script powered by Ollama that generates commit messages and pull request descriptions from code diffs using local and cloud LLMs, and tools like Claude and OpenAI Codex CLI for intelligent code review and generation. This isn't about following a trend — it's a concrete investment in shipping better quality work, faster.
           </p>
           <p>
             What drives me most is the opportunity to mentor junior developers and contribute to architectural decisions that have long-term impact on business success. I believe the best solutions come from understanding both the technical implementation and the business value they deliver.
@@ -294,7 +297,7 @@
             What's next in your professional journey?
           </h3>
           <p>
-            I'm currently seeking opportunities that leverage my combination of SAP Commerce Cloud expertise (9+ years), production-grade MuleSoft Anypoint proficiency, and growing Salesforce ecosystem confidence. My career progression demonstrates a clear specialization in integration: from implementing product imports to leading cloud-native migrations to designing API-led architectures â€” now augmented by AI tooling integrated into my daily workflow.
+            I'm currently seeking opportunities that leverage my combination of SAP Commerce Cloud expertise (9+ years), production-grade MuleSoft Anypoint proficiency, and growing Salesforce ecosystem confidence. My career progression demonstrates a clear specialization in integration: from implementing product imports to leading cloud-native migrations to designing API-led architectures — now augmented by AI tooling integrated into my daily workflow.
           </p>
           <p>
             I'm particularly interested in roles that allow me to:
@@ -303,7 +306,7 @@
             <li><strong>Lead complex integration projects</strong> connecting e-commerce platforms with enterprise ecosystems across MuleSoft and Salesforce</li>
             <li><strong>Design scalable API-led architectures</strong> that enable business agility and digital transformation</li>
             <li><strong>Bridge business and technology</strong> by applying e-commerce domain expertise to integration solutions</li>
-            <li><strong>Leverage AI tooling at scale</strong> â€” from Copilot-augmented coding to LLM-powered automation in delivery pipelines</li>
+            <li><strong>Leverage AI tooling at scale</strong> — from Copilot-augmented coding to LLM-powered automation in delivery pipelines</li>
             <li><strong>Mentor development teams</strong> on integration best practices, API design, cloud-native patterns, and AI-augmented workflows</li>
             <li><strong>Drive cloud-native transformations</strong> leveraging microservices, containers, and API management</li>
           </ul>
@@ -402,36 +405,36 @@
     </div>
 
     <div id="fr" class="lang-content">
-      <h1>Ã€ Propos</h1>
+      <h1>À Propos</h1>
       <p style="font-size: clamp(1rem, 3vw, 1.2rem); color: var(--text-muted); margin-bottom: 2rem; text-align: center; font-weight: 400; max-width: 700px; margin-left: auto; margin-right: auto; margin-bottom: 2rem;">
-        Mon parcours d'un jeune diplÃ´mÃ© ingÃ©nieur Ã  Consultant Senior en IntÃ©gration E-Commerce reliant plateformes traditionnelles aux architectures API-led modernes.
+        Mon parcours d'un jeune diplômé ingénieur à Consultant Senior en Intégration E-Commerce reliant plateformes traditionnelles aux architectures API-led modernes.
       </p>
 
       <div class="about-grid">
         <div class="about-card">
           <h3>
             <span class="card-number">I</span>
-            Comment votre parcours professionnel a-t-il commencÃ© ?
+            Comment votre parcours professionnel a-t-il commencé ?
           </h3>
           <p>
-            J'ai commencÃ© mon parcours professionnel juste aprÃ¨s l'obtention de mon diplÃ´me d'IngÃ©nieur d'Ã‰tat en Informatique & BI Ã  l'INSEA Rabat en 2015. Mon premier pas dans le monde professionnel fut un stage chez Brake.fr, oÃ¹ j'ai Ã©tÃ© initiÃ© Ã  SAP Commerce Cloud (alors appelÃ© Hybris).
+            J'ai commencé mon parcours professionnel juste après l'obtention de mon diplôme d'Ingénieur d'État en Informatique & BI à l'INSEA Rabat en 2015. Mon premier pas dans le monde professionnel fut un stage chez Brake.fr, où j'ai été initié à SAP Commerce Cloud (alors appelé Hybris).
           </p>
           <p>
-            Ce qui a commencÃ© par l'apprentissage des flux d'import produits et des personnalisations CMS s'est rapidement transformÃ© en une fascination profonde pour l'architecture e-commerce et l'intÃ©gration de systÃ¨mes. Au fil des annÃ©es, je suis devenu curieux de comprendre comment les systÃ¨mes d'entreprise complexes s'intÃ¨grent et communiquent, m'amenant Ã  maÃ®triser non seulement les aspects techniques mais aussi la logique mÃ©tier derriÃ¨re les plateformes e-commerce modernes. Cette curiositÃ© m'a naturellement conduit Ã  me spÃ©cialiser dans l'intÃ©gration d'APIs, pour finalement Ã©voluer vers MuleSoft Anypoint Platform en complÃ©ment de mon expertise SAP Commerce.
+            Ce qui a commencé par l'apprentissage des flux d'import produits et des personnalisations CMS s'est rapidement transformé en une fascination profonde pour l'architecture e-commerce et l'intégration de systèmes. Au fil des années, je suis devenu curieux de comprendre comment les systèmes d'entreprise complexes s'intègrent et communiquent, m'amenant à maîtriser non seulement les aspects techniques mais aussi la logique métier derrière les plateformes e-commerce modernes. Cette curiosité m'a naturellement conduit à me spécialiser dans l'intégration d'APIs, pour finalement évoluer vers MuleSoft Anypoint Platform en complément de mon expertise SAP Commerce.
           </p>
           <div class="timeline">
             <div class="timeline-item">
               <div class="timeline-dot"></div>
               <div class="timeline-content">
                 <div class="timeline-year">2015</div>
-                <div>DiplÃ´me d'ingÃ©nieur & premier stage chez Brake.fr</div>
+                <div>Diplôme d'ingénieur & premier stage chez Brake.fr</div>
               </div>
             </div>
             <div class="timeline-item">
               <div class="timeline-dot"></div>
               <div class="timeline-content">
                 <div class="timeline-year">2016-2018</div>
-                <div>SEB Group - SpÃ©cialiste intÃ©gration multi-marques</div>
+                <div>SEB Group - Spécialiste intégration multi-marques</div>
               </div>
             </div>
             <div class="timeline-item">
@@ -452,7 +455,7 @@
               <div class="timeline-dot"></div>
               <div class="timeline-content">
                 <div class="timeline-year">2025-Aujourd'hui</div>
-                <div>Roche Bobois - SpÃ©cialiste intÃ©gration MuleSoft</div>
+                <div>Roche Bobois - Spécialiste intégration MuleSoft</div>
               </div>
             </div>
           </div>
@@ -464,52 +467,52 @@
             Qu'est-ce qui alimente votre passion pour la technologie ?
           </h3>
           <p>
-            Je suis passionnÃ© par la construction de solutions d'intÃ©gration robustes et Ã©volutives qui connectent les systÃ¨mes d'entreprise complexes de maniÃ¨re transparente. Ma combinaison unique d'expertise approfondie en SAP Commerce Cloud et de compÃ©tences MuleSoft Anypoint me permet de faire le pont entre les plateformes e-commerce traditionnelles et les architectures d'intÃ©gration API-led modernes.
+            Je suis passionné par la construction de solutions d'intégration robustes et évolutives qui connectent les systèmes d'entreprise complexes de manière transparente. Ma combinaison unique d'expertise approfondie en SAP Commerce Cloud et de compétences MuleSoft Anypoint me permet de faire le pont entre les plateformes e-commerce traditionnelles et les architectures d'intégration API-led modernes.
           </p>
           <p>
-            Tout au long de mes 8+ annÃ©es de carriÃ¨re, j'ai Ã©voluÃ© de l'implÃ©mentation de catalogues produits Ã  l'architecture d'Ã©cosystÃ¨mes d'intÃ©gration complets. Mon expertise couvre le spectre complet de l'intÃ©gration : de la conception d'APIs OCC pour le commerce headless Ã  la construction de transformations DataWeave pour l'orchestration de donnÃ©es complexes, de l'implÃ©mentation de microservices sur Kubernetes Ã  l'Ã©tablissement de frameworks de gouvernance API. Actuellement chez Roche Bobois, je me concentre sur l'optimisation de workflows, l'implÃ©mentation de patterns d'orchestration sophistiquÃ©s, et la construction de mÃ©canismes de gestion d'erreurs enterprise pour assurer la fiabilitÃ© systÃ¨me et la continuitÃ© mÃ©tier.
+            Tout au long de mes 8+ années de carrière, j'ai évolué de l'implémentation de catalogues produits à l'architecture d'écosystèmes d'intégration complets. Mon expertise couvre le spectre complet de l'intégration : de la conception d'APIs OCC pour le commerce headless à la construction de transformations DataWeave pour l'orchestration de données complexes, de l'implémentation de microservices sur Kubernetes à l'établissement de frameworks de gouvernance API. Actuellement chez Roche Bobois, je me concentre sur l'optimisation de workflows, l'implémentation de patterns d'orchestration sophistiqués, et la construction de mécanismes de gestion d'erreurs enterprise pour assurer la fiabilité système et la continuité métier.
           </p>
           <p>
-            Je suis un apprenant perpÃ©tuel qui s'Ã©panouit en restant Ã  jour avec les technologies Ã©mergentes. Que ce soit maÃ®triser les principes d'API-led connectivity, implÃ©menter des architectures cloud-native, ou optimiser les performances des systÃ¨mes, j'adore plonger dans les dÃ©fis techniques et partager mes connaissances avec mon Ã©quipe.
+            Je suis un apprenant perpétuel qui s'épanouit en restant à jour avec les technologies émergentes. Que ce soit maîtriser les principes d'API-led connectivity, implémenter des architectures cloud-native, ou optimiser les performances des systèmes, j'adore plonger dans les défis techniques et partager mes connaissances avec mon équipe.
           </p>
           <p>
-            Au-delÃ  des plateformes d'intÃ©gration, j'ai fait du dÃ©veloppement augmentÃ© par IA une pratique centrale. J'utilise GitHub Copilot pour l'accÃ©lÃ©ration quotidienne du code, un script CLI personnalisÃ© alimentÃ© par Ollama qui gÃ©nÃ¨re des messages de commit et descriptions de pull requests Ã  partir de diffs de code avec des LLMs locaux et cloud, ainsi que Claude et OpenAI Codex CLI pour la revue et gÃ©nÃ©ration de code intelligente. Ce n'est pas suivre une tendance â€” c'est un investissement concret pour livrer un travail de meilleure qualitÃ©, plus rapidement.
+            Au-delà des plateformes d'intégration, j'ai fait du développement augmenté par IA une pratique centrale. J'utilise GitHub Copilot pour l'accélération quotidienne du code, un script CLI personnalisé alimenté par Ollama qui génère des messages de commit et descriptions de pull requests à partir de diffs de code avec des LLMs locaux et cloud, ainsi que Claude et OpenAI Codex CLI pour la revue et génération de code intelligente. Ce n'est pas suivre une tendance — c'est un investissement concret pour livrer un travail de meilleure qualité, plus rapidement.
           </p>
           <p>
-            Ce qui me motive le plus, c'est l'opportunitÃ© de mentorer les dÃ©veloppeurs juniors et de contribuer aux dÃ©cisions architecturales qui ont un impact Ã  long terme sur le succÃ¨s de l'entreprise. Je crois que les meilleures solutions viennent de la comprÃ©hension Ã  la fois de l'implÃ©mentation technique et de la valeur mÃ©tier qu'elles apportent.
+            Ce qui me motive le plus, c'est l'opportunité de mentorer les développeurs juniors et de contribuer aux décisions architecturales qui ont un impact à long terme sur le succès de l'entreprise. Je crois que les meilleures solutions viennent de la compréhension à la fois de l'implémentation technique et de la valeur métier qu'elles apportent.
           </p>
         </div>
 
         <div class="about-card">
           <h3>
             <span class="card-number">III</span>
-            Quelle est la prochaine Ã©tape de votre parcours professionnel ?
+            Quelle est la prochaine étape de votre parcours professionnel ?
           </h3>
           <p>
-            Je recherche actuellement des opportunitÃ©s qui tirent parti de ma combinaison d'expertise SAP Commerce Cloud (9+ ans), de maÃ®trise avÃ©rÃ©e de MuleSoft Anypoint et de confiance grandissante dans l'Ã©cosystÃ¨me Salesforce. Mon Ã©volution de carriÃ¨re dÃ©montre une spÃ©cialisation claire en intÃ©gration : de l'implÃ©mentation d'imports produits Ã  la direction de migrations cloud-native jusqu'Ã  la conception d'architectures API-led â€” dÃ©sormais augmentÃ©e par des outils IA intÃ©grÃ©s Ã  mon workflow quotidien.
+            Je recherche actuellement des opportunités qui tirent parti de ma combinaison d'expertise SAP Commerce Cloud (9+ ans), de maîtrise avérée de MuleSoft Anypoint et de confiance grandissante dans l'écosystème Salesforce. Mon évolution de carrière démontre une spécialisation claire en intégration : de l'implémentation d'imports produits à la direction de migrations cloud-native jusqu'à la conception d'architectures API-led — désormais augmentée par des outils IA intégrés à mon workflow quotidien.
           </p>
           <p>
-            Je suis particuliÃ¨rement intÃ©ressÃ© par des rÃ´les qui me permettent de :
+            Je suis particulièrement intéressé par des rôles qui me permettent de :
           </p>
           <ul>
-            <li><strong>Diriger des projets d'intÃ©gration complexes</strong> connectant plateformes e-commerce aux Ã©cosystÃ¨mes d'entreprise MuleSoft et Salesforce</li>
-            <li><strong>Concevoir des architectures API-led scalables</strong> qui permettent l'agilitÃ© mÃ©tier et la transformation digitale</li>
-            <li><strong>Faire le pont entre business et technologie</strong> en appliquant l'expertise mÃ©tier e-commerce aux solutions d'intÃ©gration</li>
-            <li><strong>Tirer parti des outils IA Ã  grande Ã©chelle</strong> â€” du code augmentÃ© Copilot Ã  l'automatisation LLM dans les pipelines de livraison</li>
-            <li><strong>Encadrer des Ã©quipes de dÃ©veloppement</strong> sur les bonnes pratiques d'intÃ©gration, conception d'API, patterns cloud-native et workflows augmentÃ©s par IA</li>
+            <li><strong>Diriger des projets d'intégration complexes</strong> connectant plateformes e-commerce aux écosystèmes d'entreprise MuleSoft et Salesforce</li>
+            <li><strong>Concevoir des architectures API-led scalables</strong> qui permettent l'agilité métier et la transformation digitale</li>
+            <li><strong>Faire le pont entre business et technologie</strong> en appliquant l'expertise métier e-commerce aux solutions d'intégration</li>
+            <li><strong>Tirer parti des outils IA à grande échelle</strong> — du code augmenté Copilot à l'automatisation LLM dans les pipelines de livraison</li>
+            <li><strong>Encadrer des équipes de développement</strong> sur les bonnes pratiques d'intégration, conception d'API, patterns cloud-native et workflows augmentés par IA</li>
             <li><strong>Piloter des transformations cloud-native</strong> exploitant microservices, conteneurs et gestion d'API</li>
           </ul>
           <p>
-            Avec plus de 9 ans d'expÃ©rience dans l'e-commerce d'entreprise, une expertise prouvÃ©e en SAP Commerce Cloud, MuleSoft Anypoint et Salesforce, et un historique de migrations, d'intÃ©grations et de livraisons augmentÃ©es par IA rÃ©ussies, je suis prÃªt Ã  relever de nouveaux dÃ©fis qui repoussent les limites du possible dans les technologies de commerce modernes.
+            Avec plus de 9 ans d'expérience dans l'e-commerce d'entreprise, une expertise prouvée en SAP Commerce Cloud, MuleSoft Anypoint et Salesforce, et un historique de migrations, d'intégrations et de livraisons augmentées par IA réussies, je suis prêt à relever de nouveaux défis qui repoussent les limites du possible dans les technologies de commerce modernes.
           </p>
         </div>
       </div>
 
       <div class="skills-section">
-        <h2>Mes CompÃ©tences</h2>
+        <h2>Mes Compétences</h2>
         <div class="skills-grid">
           <div class="skills-table">
-            <h3>CompÃ©tences Techniques</h3>
+            <h3>Compétences Techniques</h3>
             <div class="skill-category">
               <h4>Langages de Programmation</h4>
               <div class="skill-list">
@@ -552,7 +555,7 @@
               </div>
             </div>
             <div class="skill-category">
-              <h4>Bases de DonnÃ©es & Outils</h4>
+              <h4>Bases de Données & Outils</h4>
               <div class="skill-list">
                 <span class="skill-item">MySQL</span>
                 <span class="skill-item">SAP Hana</span>
@@ -565,29 +568,29 @@
           </div>
 
           <div class="skills-table">
-            <h3>CompÃ©tences Transversales</h3>
+            <h3>Compétences Transversales</h3>
             <div class="soft-skills">
-              <div class="soft-skill-item">Leadership d'Ã‰quipe</div>
+              <div class="soft-skill-item">Leadership d'Équipe</div>
               <div class="soft-skill-item">Mentorat</div>
-              <div class="soft-skill-item">RÃ©solution de ProblÃ¨mes</div>
+              <div class="soft-skill-item">Résolution de Problèmes</div>
               <div class="soft-skill-item">Communication</div>
-              <div class="soft-skill-item">MÃ©thodes Agiles</div>
+              <div class="soft-skill-item">Méthodes Agiles</div>
               <div class="soft-skill-item">Gestion de Projet</div>
               <div class="soft-skill-item">Architecture Technique</div>
               <div class="soft-skill-item">Revue de Code</div>
               <div class="soft-skill-item">Relations Client</div>
               <div class="soft-skill-item">Apprentissage Continu</div>
               <div class="soft-skill-item">Collaboration Transverse</div>
-              <div class="soft-skill-item">Planification StratÃ©gique</div>
+              <div class="soft-skill-item">Planification Stratégique</div>
             </div>
           </div>
         </div>
       </div>
 
           <div class="cta-section">
-            <h3>PrÃªt Ã  travailler ensemble ?</h3>
+            <h3>Prêt à travailler ensemble ?</h3>
             <p>
-              Discutons de la faÃ§on dont ma combinaison unique d'expertise SAP Commerce Cloud et de compÃ©tences d'intÃ©gration MuleSoft peut aider Ã  mener votre prochain projet de transformation e-commerce ou d'intÃ©gration vers le succÃ¨s.
+              Discutons de la façon dont ma combinaison unique d'expertise SAP Commerce Cloud et de compétences d'intégration MuleSoft peut aider à mener votre prochain projet de transformation e-commerce ou d'intégration vers le succès.
             </p>
             <a href="mailto:b.bousnguar@gmail.com" class="cta-button">Contactez-moi</a>
           </div>

--- a/pages/about.html
+++ b/pages/about.html
@@ -43,8 +43,21 @@
   <link rel="icon" type="image/png" href="../assets/img/favicon.png">
   <link rel="apple-touch-icon" sizes="180x180" href="../assets/img/favicon.png">
   <meta name="theme-color" content="#0066ff">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <!-- Pre-paint theme/language restore (must stay inline to avoid flash of wrong theme) -->
+  <script>
+    (function () {
+      var theme = localStorage.getItem('theme') ||
+        (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', theme);
+      var lang = localStorage.getItem('language') || 'en';
+      document.documentElement.setAttribute('lang', lang);
+      document.documentElement.setAttribute('data-lang', lang);
+      document.documentElement.classList.add('js');
+    })();
+  </script>
   <link rel="stylesheet" href="../assets/css/style.css">
+  <script src="../assets/js/main.js" defer></script>
   <link rel="stylesheet" href="../assets/css/about.css">
   
   <!-- Breadcrumb Structured Data -->
@@ -66,86 +79,6 @@
   }
   </script>
   
-  <script>
-    function switchLang(lang) {
-      document.querySelectorAll('.lang-content').forEach(el => el.classList.remove('active'));
-      document.querySelectorAll('.lang-toggle button').forEach(btn => btn.classList.remove('active'));
-      const selected = document.getElementById(lang);
-      if (selected) selected.classList.add('active');
-      const btn = document.querySelector(`.lang-toggle button[onclick*="${lang}"]`);
-      if (btn) btn.classList.add('active');
-      
-      // Update HTML lang attribute for SEO and accessibility
-      document.documentElement.setAttribute('lang', lang);
-      document.documentElement.setAttribute('data-lang', lang);
-    }
-    
-    function toggleTheme() {
-      const currentTheme = document.documentElement.getAttribute('data-theme');
-      const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-      
-      document.documentElement.setAttribute('data-theme', newTheme);
-      localStorage.setItem('theme', newTheme);
-      
-      // Update toggle button
-      const lightOption = document.getElementById('light-option');
-      const darkOption = document.getElementById('dark-option');
-      
-      if (newTheme === 'light') {
-        lightOption.classList.add('active');
-        darkOption.classList.remove('active');
-      } else {
-        darkOption.classList.add('active');
-        lightOption.classList.remove('active');
-      }
-    }
-    
-    window.onload = function () {
-      // Load saved language preference or default to English
-      const savedLang = localStorage.getItem('language') || 'en';
-      switchLang(savedLang);
-      
-      // Ensure HTML lang attribute is set on initial load
-      document.documentElement.setAttribute('lang', savedLang);
-      
-      // Detect system theme preference
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      const savedTheme = localStorage.getItem('theme');
-      
-      // Use saved theme if available, otherwise use system preference (default to light)
-      const defaultTheme = savedTheme || (prefersDark ? 'dark' : 'light');
-      
-      document.documentElement.setAttribute('data-theme', defaultTheme);
-      
-      // Update toggle button based on theme
-      const lightOption = document.getElementById('light-option');
-      const darkOption = document.getElementById('dark-option');
-      
-      if (defaultTheme === 'light') {
-        lightOption.classList.add('active');
-        darkOption.classList.remove('active');
-      } else {
-        darkOption.classList.add('active');
-        lightOption.classList.remove('active');
-      }
-      
-      // Listen for system theme changes
-      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-        if (!localStorage.getItem('theme')) { // Only auto-switch if user hasn't set a preference
-          const newTheme = e.matches ? 'dark' : 'light';
-          document.documentElement.setAttribute('data-theme', newTheme);
-          
-          if (newTheme === 'light') {
-            lightOption.classList.add('active');
-            darkOption.classList.remove('active');
-          } else {
-            darkOption.classList.add('active');
-            lightOption.classList.remove('active');
-          }
-        }
-      });
-    };
-  </script>
 </head>
 <body>
   <!-- Skip to main content link for accessibility -->

--- a/pages/about.html
+++ b/pages/about.html
@@ -79,7 +79,48 @@
     }]
   }
   </script>
-  
+
+  <!-- Person Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Brahim Bousnguar",
+    "givenName": "Brahim",
+    "familyName": "Bousnguar",
+    "jobTitle": "Senior E-Commerce Integration Consultant",
+    "description": "Senior E-Commerce Integration Consultant with 9+ years of experience. Career journey from SAP Commerce internship in 2015 to leading cloud-native migrations and API-led integration architectures across SEB Group, BYK, Miele and Roche Bobois.",
+    "url": "https://brbousnguar.github.io/",
+    "email": "b.bousnguar@gmail.com",
+    "image": "https://brbousnguar.github.io/assets/img/profile.jpeg",
+    "sameAs": [
+      "https://github.com/brbousnguar",
+      "https://www.linkedin.com/in/brahim-bousnguar/"
+    ],
+    "knowsAbout": [
+      "SAP Commerce Cloud",
+      "MuleSoft Anypoint Platform",
+      "Salesforce",
+      "API Integration",
+      "Microservices",
+      "Cloud Migration",
+      "AI-augmented development"
+    ],
+    "alumniOf": {
+      "@type": "EducationalOrganization",
+      "name": "INSEA Rabat"
+    },
+    "worksFor": {
+      "@type": "Organization",
+      "name": "Roche Bobois"
+    },
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "https://brbousnguar.github.io/pages/about.html"
+    }
+  }
+  </script>
+
 </head>
 <body>
   <!-- Skip to main content link for accessibility -->
@@ -125,13 +166,16 @@
     <aside class="sidebar">
       <ul class="sidebar-nav">
         <li><a href="../index.html#hero">Overview</a></li>
-        <li><a href="../index.html#value-proposition">Value</a></li>
-        <li><a href="../index.html#professional-experience">Experience</a></li>
+        <li><a href="../index.html#value-proposition">Value Proposition</a></li>
         <li><a href="../index.html#projects">Projects</a></li>
         <li><a href="../index.html#skills">Skills</a></li>
         <li><a href="../index.html#certifications">Certifications</a></li>
+        <li><a href="../index.html#continuous-learning">Learning</a></li>
+        <li><a href="learning.html">All Certificates</a></li>
+        <li><a href="../index.html#professional-experience">Experience</a></li>
         <li><a href="../index.html#education">Education</a></li>
         <li><a href="../index.html#faq">FAQ</a></li>
+        <li><a href="../index.html#contact">Contact</a></li>
         <li><a href="about.html" class="active">About Me</a></li>
       </ul>
     </aside>
@@ -148,12 +192,12 @@
 
         <div id="en" class="lang-content">
           <h1>About Me</h1>
-          <p style="font-size: 1.125rem; color: var(--text-secondary); margin-bottom: 2rem; font-weight: 400;">
+          <p class="about-intro">
             My journey from a fresh engineering graduate to a Senior E-Commerce Integration Consultant bridging traditional platforms with modern API-led architectures.
           </p>
 
-      <div class="about-grid">
-        <div class="about-card">
+      <div class="about-grid" data-stagger>
+        <div class="about-card reveal">
           <h3>
             <span class="card-number">I</span>
             How did your career journey begin?
@@ -203,7 +247,7 @@
           </div>
         </div>
 
-        <div class="about-card">
+        <div class="about-card reveal">
           <h3>
             <span class="card-number">II</span>
             What drives your passion for technology?
@@ -225,7 +269,7 @@
           </p>
         </div>
 
-        <div class="about-card">
+        <div class="about-card reveal">
           <h3>
             <span class="card-number">III</span>
             What's next in your professional journey?
@@ -253,7 +297,7 @@
       <div class="skills-section">
         <h2>My Skills</h2>
         <div class="skills-grid">
-          <div class="skills-table">
+          <div class="skills-table reveal">
             <h3>Technical Skills</h3>
             <div class="skill-category">
               <h4>Programming Languages</h4>
@@ -309,7 +353,7 @@
             </div>
           </div>
 
-          <div class="skills-table">
+          <div class="skills-table reveal">
             <h3>Soft Skills</h3>
             <div class="soft-skills">
               <div class="soft-skill-item">Team Leadership</div>
@@ -329,7 +373,7 @@
         </div>
       </div>
 
-      <div class="cta-section">
+      <div class="cta-section reveal">
         <h3>Ready to work together?</h3>
         <p>
           Let's discuss how my unique combination of SAP Commerce Cloud expertise and MuleSoft integration skills can help drive your next e-commerce transformation or integration project to success.
@@ -340,12 +384,12 @@
 
     <div id="fr" class="lang-content">
       <h1>À Propos</h1>
-      <p style="font-size: clamp(1rem, 3vw, 1.2rem); color: var(--text-muted); margin-bottom: 2rem; text-align: center; font-weight: 400; max-width: 700px; margin-left: auto; margin-right: auto; margin-bottom: 2rem;">
+      <p class="about-intro">
         Mon parcours d'un jeune diplômé ingénieur à Consultant Senior en Intégration E-Commerce reliant plateformes traditionnelles aux architectures API-led modernes.
       </p>
 
-      <div class="about-grid">
-        <div class="about-card">
+      <div class="about-grid" data-stagger>
+        <div class="about-card reveal">
           <h3>
             <span class="card-number">I</span>
             Comment votre parcours professionnel a-t-il commencé ?
@@ -395,7 +439,7 @@
           </div>
         </div>
 
-        <div class="about-card">
+        <div class="about-card reveal">
           <h3>
             <span class="card-number">II</span>
             Qu'est-ce qui alimente votre passion pour la technologie ?
@@ -417,7 +461,7 @@
           </p>
         </div>
 
-        <div class="about-card">
+        <div class="about-card reveal">
           <h3>
             <span class="card-number">III</span>
             Quelle est la prochaine étape de votre parcours professionnel ?
@@ -445,7 +489,7 @@
       <div class="skills-section">
         <h2>Mes Compétences</h2>
         <div class="skills-grid">
-          <div class="skills-table">
+          <div class="skills-table reveal">
             <h3>Compétences Techniques</h3>
             <div class="skill-category">
               <h4>Langages de Programmation</h4>
@@ -501,7 +545,7 @@
             </div>
           </div>
 
-          <div class="skills-table">
+          <div class="skills-table reveal">
             <h3>Compétences Transversales</h3>
             <div class="soft-skills">
               <div class="soft-skill-item">Leadership d'Équipe</div>
@@ -521,7 +565,7 @@
         </div>
       </div>
 
-          <div class="cta-section">
+          <div class="cta-section reveal">
             <h3>Prêt à travailler ensemble ?</h3>
             <p>
               Discutons de la façon dont ma combinaison unique d'expertise SAP Commerce Cloud et de compétences d'intégration MuleSoft peut aider à mener votre prochain projet de transformation e-commerce ou d'intégration vers le succès.

--- a/pages/learning.html
+++ b/pages/learning.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en" data-lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -202,7 +202,7 @@
             <path d="M30,0 v30 M0,15 h60" stroke="#C8102E" stroke-width="6"/></g>
           </svg>
         </button>
-        <button onclick="switchLang('fr')" aria-label="Switch to French" title="FranÃ§ais">
+        <button onclick="switchLang('fr')" aria-label="Switch to French" title="Français">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" width="24" height="16">
             <rect width="900" height="600" fill="#ED2939"/>
             <rect width="600" height="600" fill="#fff"/>
@@ -211,8 +211,8 @@
         </button>
       </div>
       <div class="theme-toggle" onclick="toggleTheme()">
-        <button class="theme-toggle-option" id="light-option" aria-label="Light mode">â˜€ï¸</button>
-        <button class="theme-toggle-option" id="dark-option" aria-label="Dark mode">ðŸŒ™</button>
+        <button class="theme-toggle-option" id="light-option" aria-label="Light mode">☀️</button>
+        <button class="theme-toggle-option" id="dark-option" aria-label="Dark mode">🌙</button>
       </div>
     </div>
   </header>
@@ -242,7 +242,7 @@
         <!-- Breadcrumb -->
         <nav class="breadcrumb" aria-label="Breadcrumb">
           <a href="../index.html">Home</a>
-          <span class="separator" aria-hidden="true">â€º</span>
+          <span class="separator" aria-hidden="true">›</span>
           <span>Learning & Certifications</span>
         </nav>
 
@@ -250,7 +250,7 @@
           <!-- Page Header -->
           <section class="learning-header">
             <h1>LinkedIn Learning Certificates</h1>
-            <p class="learning-subtitle">A curated collection of 409 LinkedIn Learning certificates demonstrating strategic cross-domain learning across 12+ technology domains. This page showcases only LinkedIn Learning achievementsâ€”organized by domain, year, and skills.</p>
+            <p class="learning-subtitle">A curated collection of 409 LinkedIn Learning certificates demonstrating strategic cross-domain learning across 12+ technology domains. This page showcases only LinkedIn Learning achievements—organized by domain, year, and skills.</p>
           </section>
 
           <!-- Statistics Dashboard -->
@@ -389,8 +389,8 @@
               <section class="results-info">
                 <p id="results-count">Showing <strong>409</strong> certificates</p>
                 <div class="view-toggle">
-                  <button id="grid-view" class="view-btn" aria-label="Grid view">âŠž Grid</button>
-                  <button id="list-view" class="view-btn active" aria-label="List view">â˜° List</button>
+                  <button id="grid-view" class="view-btn" aria-label="Grid view">⊞ Grid</button>
+                  <button id="list-view" class="view-btn active" aria-label="List view">☰ List</button>
                 </div>
               </section>
 
@@ -407,7 +407,7 @@
           <!-- Learning Philosophy -->
           <section class="learning-philosophy-section">
             <h2>Learning Philosophy</h2>
-            <p>My learning approach is structured around building a comprehensive tech culture that adapts to industry changes. By systematically covering multiple domainsâ€”from programming fundamentals to cloud platforms, from DevOps practices to AI toolsâ€”I ensure continuous growth and domain-agnostic expertise. This cross-domain learning strategy makes me adaptable to technology shifts and ready for diverse project challenges.</p>
+            <p>My learning approach is structured around building a comprehensive tech culture that adapts to industry changes. By systematically covering multiple domains—from programming fundamentals to cloud platforms, from DevOps practices to AI tools—I ensure continuous growth and domain-agnostic expertise. This cross-domain learning strategy makes me adaptable to technology shifts and ready for diverse project challenges.</p>
             <div class="philosophy-points">
               <div class="philosophy-point">
                 <strong>Systematic Learning:</strong> Structured approach covering all major technology domains
@@ -429,7 +429,7 @@
           <!-- Page Header -->
           <section class="learning-header">
             <h1>Certificats LinkedIn Learning</h1>
-            <p class="learning-subtitle">Une collection de 409 certificats LinkedIn Learning dÃ©montrant un apprentissage stratÃ©gique transdisciplinaire Ã  travers 12+ domaines technologiques. Cette page prÃ©sente uniquement les rÃ©alisations LinkedIn Learningâ€”organisÃ©es par domaine, annÃ©e et compÃ©tences.</p>
+            <p class="learning-subtitle">Une collection de 409 certificats LinkedIn Learning démontrant un apprentissage stratégique transdisciplinaire à travers 12+ domaines technologiques. Cette page présente uniquement les réalisations LinkedIn Learning—organisées par domaine, année et compétences.</p>
           </section>
 
           <!-- Statistics Dashboard -->
@@ -467,7 +467,7 @@
               </div>
               <div class="stat-content">
                 <div class="stat-number" id="active-years-fr">6+</div>
-                <div class="stat-label">AnnÃ©es Actives</div>
+                <div class="stat-label">Années Actives</div>
               </div>
             </div>
             <div class="stat-card-large">
@@ -504,7 +504,7 @@
                 
                 <!-- Skills Filter -->
                 <div class="skills-filter-section" id="skills-filter-fr">
-                  <label class="skills-filter-label">Filtrer par CompÃ©tences</label>
+                  <label class="skills-filter-label">Filtrer par Compétences</label>
                   <div class="skills-list" id="skills-list-fr">
                     <!-- Skills will be dynamically loaded here -->
                   </div>
@@ -517,24 +517,24 @@
                     <option value="all">Tous les Domaines</option>
                     <option value="programming">Programmation & Backend</option>
                     <option value="cloud">Plateformes Cloud</option>
-                    <option value="frontend">DÃ©veloppement Frontend</option>
+                    <option value="frontend">Développement Frontend</option>
                     <option value="devops">DevOps & Infrastructure</option>
                     <option value="ai">Intelligence Artificielle</option>
                     <option value="agile">Agile & Gestion de Projet</option>
                     <option value="ecommerce">E-Commerce & SEO</option>
                     <option value="communication">Communication</option>
-                    <option value="tools">Outils de DÃ©veloppement</option>
-                    <option value="security">SÃ©curitÃ©</option>
-                    <option value="data">DonnÃ©es & Analytique</option>
+                    <option value="tools">Outils de Développement</option>
+                    <option value="security">Sécurité</option>
+                    <option value="data">Données & Analytique</option>
                     <option value="other">Autre</option>
                   </select>
                 </div>
                 
                 <!-- Year Filter -->
                 <div class="filter-group">
-                  <label for="year-filter-fr">AnnÃ©e</label>
-                  <select id="year-filter-fr" aria-label="Filtrer par annÃ©e">
-                    <option value="all">Toutes les AnnÃ©es</option>
+                  <label for="year-filter-fr">Année</label>
+                  <select id="year-filter-fr" aria-label="Filtrer par année">
+                    <option value="all">Toutes les Années</option>
                     <option value="2026">2026</option>
                     <option value="2025">2025</option>
                     <option value="2024">2024</option>
@@ -546,7 +546,7 @@
                 <div class="filter-group">
                   <label for="sort-filter-fr">Trier par</label>
                   <select id="sort-filter-fr" aria-label="Trier les certificats">
-                    <option value="date-desc">Date (Plus RÃ©cent)</option>
+                    <option value="date-desc">Date (Plus Récent)</option>
                     <option value="date-asc">Date (Plus Ancien)</option>
                     <option value="title-asc">Titre (A-Z)</option>
                     <option value="title-desc">Titre (Z-A)</option>
@@ -568,8 +568,8 @@
               <section class="results-info">
                 <p id="results-count-fr">Affichage de <strong>409</strong> certificats</p>
                 <div class="view-toggle">
-                  <button id="grid-view-fr" class="view-btn" aria-label="Vue grille">âŠž Grille</button>
-                  <button id="list-view-fr" class="view-btn active" aria-label="Vue liste">â˜° Liste</button>
+                  <button id="grid-view-fr" class="view-btn" aria-label="Vue grille">⊞ Grille</button>
+                  <button id="list-view-fr" class="view-btn active" aria-label="Vue liste">☰ Liste</button>
                 </div>
               </section>
 
@@ -586,19 +586,19 @@
           <!-- Learning Philosophy -->
           <section class="learning-philosophy-section">
             <h2>Philosophie d'Apprentissage</h2>
-            <p>Mon approche d'apprentissage est structurÃ©e autour de la construction d'une culture tech complÃ¨te qui s'adapte aux changements de l'industrie. En couvrant systÃ©matiquement plusieurs domainesâ€”des fondamentaux de programmation aux plateformes cloud, des pratiques DevOps aux outils IAâ€”je garantis une croissance continue et une expertise indÃ©pendante du domaine. Cette stratÃ©gie d'apprentissage transdisciplinaire me rend adaptable aux changements technologiques et prÃªt pour des dÃ©fis de projets diversifiÃ©s.</p>
+            <p>Mon approche d'apprentissage est structurée autour de la construction d'une culture tech complète qui s'adapte aux changements de l'industrie. En couvrant systématiquement plusieurs domaines—des fondamentaux de programmation aux plateformes cloud, des pratiques DevOps aux outils IA—je garantis une croissance continue et une expertise indépendante du domaine. Cette stratégie d'apprentissage transdisciplinaire me rend adaptable aux changements technologiques et prêt pour des défis de projets diversifiés.</p>
             <div class="philosophy-points">
               <div class="philosophy-point">
-                <strong>Apprentissage SystÃ©matique:</strong> Approche structurÃ©e couvrant tous les domaines technologiques majeurs
+                <strong>Apprentissage Systématique:</strong> Approche structurée couvrant tous les domaines technologiques majeurs
               </div>
               <div class="philosophy-point">
-                <strong>IndÃ©pendant du Domaine:</strong> Construction d'une expertise qui transcende les technologies spÃ©cifiques
+                <strong>Indépendant du Domaine:</strong> Construction d'une expertise qui transcende les technologies spécifiques
               </div>
               <div class="philosophy-point">
-                <strong>Croissance Continue:</strong> Apprentissage rÃ©gulier pour rester Ã  jour avec les tendances de l'industrie
+                <strong>Croissance Continue:</strong> Apprentissage régulier pour rester à jour avec les tendances de l'industrie
               </div>
               <div class="philosophy-point">
-                <strong>Application Pratique:</strong> Apprentissage axÃ© sur la rÃ©solution de problÃ¨mes rÃ©els
+                <strong>Application Pratique:</strong> Apprentissage axé sur la résolution de problèmes réels
               </div>
             </div>
           </section>

--- a/pages/learning.html
+++ b/pages/learning.html
@@ -734,7 +734,7 @@
           <!-- Page Header -->
           <section class="learning-header">
             <h1>LinkedIn Learning Certificates</h1>
-            <p class="learning-subtitle">A curated collection of 411 LinkedIn Learning certificates demonstrating strategic cross-domain learning across 12+ technology domains. This page showcases only LinkedIn Learning achievements—organized by domain, year, and skills.</p>
+            <p class="learning-subtitle">A growing collection of 411+ LinkedIn Learning certificates spanning 12+ technology domains — an intensive cross-domain foundation built since 2023, continuing today with a focus on agentic AI, MCP, and AI orchestration. Organized by domain, year, and skills.</p>
           </section>
 
           <!-- Statistics Dashboard -->
@@ -913,7 +913,7 @@
           <!-- Page Header -->
           <section class="learning-header">
             <h1>Certificats LinkedIn Learning</h1>
-            <p class="learning-subtitle">Une collection de 411 certificats LinkedIn Learning démontrant un apprentissage stratégique transdisciplinaire à travers 12+ domaines technologiques. Cette page présente uniquement les réalisations LinkedIn Learning—organisées par domaine, année et compétences.</p>
+            <p class="learning-subtitle">Une collection croissante de 411+ certificats LinkedIn Learning couvrant 12+ domaines technologiques — une fondation transdisciplinaire intensive construite depuis 2023, qui se poursuit aujourd'hui avec un cap sur l'IA agentique, MCP et l'orchestration d'IA. Organisée par domaine, année et compétences.</p>
           </section>
 
           <!-- Statistics Dashboard -->

--- a/pages/learning.html
+++ b/pages/learning.html
@@ -79,19 +79,579 @@
     }]
   }
   </script>
-  
-  <!-- Course Collection Structured Data for SEO -->
+
+  <!-- Collection Page Structured Data -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
     "name": "Continuous Learning & Certifications - Brahim Bousnguar",
-    "description": "400+ LinkedIn Learning certificates across Programming, Cloud, AI, DevOps, E-Commerce, and more",
+    "description": "411 LinkedIn Learning certificates across 11 technology domains including AI, Programming, Cloud, DevOps, and APIs",
     "url": "https://brbousnguar.github.io/pages/learning.html",
     "mainEntity": {
       "@type": "ItemList",
-      "numberOfItems": 409,
-      "itemListElement": []
+      "numberOfItems": 411,
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "item": {
+            "@type": "Course",
+            "name": "Agile Development in the New World of Work",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-19",
+            "timeRequired": "30m",
+            "about": [
+              "Agile Development"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "item": {
+            "@type": "Course",
+            "name": "Understanding the Impact of Deepfake Videos",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-18",
+            "timeRequired": "48m",
+            "about": [
+              "Media Literacy",
+              "Media Psychology"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "item": {
+            "@type": "Course",
+            "name": "Generative AI Skills for Creative Content: Opportunities, Issues, and Ethics",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-17",
+            "timeRequired": "1h 2m",
+            "about": [
+              "Artificial Intelligence",
+              "Design AI",
+              "Media Ethics"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 4,
+          "item": {
+            "@type": "Course",
+            "name": "Nano Tips to Foster a Growth Mindset and Mental Agility with Shadé Zahrai",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-16",
+            "timeRequired": "7m",
+            "about": [
+              "Personal Development",
+              "Critical Thinking"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 5,
+          "item": {
+            "@type": "Course",
+            "name": "Nano Tips to Enhance Your Communication with Shadé Zahrai",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-16",
+            "timeRequired": "8m",
+            "about": [
+              "Interpersonal Communication"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 6,
+          "item": {
+            "@type": "Course",
+            "name": "DALL-E: the Creative Process and the Art of Prompting",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-15",
+            "timeRequired": "56m",
+            "about": [
+              "Artificial Intelligence",
+              "Design AI",
+              "AI Prompting",
+              "Solutions"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 7,
+          "item": {
+            "@type": "Course",
+            "name": "Copilot in Teams: Power User Tips to Unlock Productivity",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-15",
+            "timeRequired": "1h 22m",
+            "about": [
+              "Microsoft Copilot",
+              "Artificial Intelligence",
+              "Microsoft Teams",
+              "AI"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 8,
+          "item": {
+            "@type": "Course",
+            "name": "10 minutes, un livre : Trouver sa voie grâce à l’ikigaï",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-15",
+            "timeRequired": "10m",
+            "about": [
+              "Personal Development"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 9,
+          "item": {
+            "@type": "Course",
+            "name": "10 minutes, un livre : Antifragilité, transformer les crises en opportunité",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-15",
+            "timeRequired": "10m",
+            "about": [
+              "Personal Development",
+              "Self Help"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 10,
+          "item": {
+            "@type": "Course",
+            "name": "10 minutes, 1 livre : 3 compétences pour être un bon manager",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-15",
+            "timeRequired": "10m",
+            "about": [
+              "Workplace Relations",
+              "People Management"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 11,
+          "item": {
+            "@type": "Course",
+            "name": "Microsoft Copilot for Azure SQL Database",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-14",
+            "timeRequired": "22m",
+            "about": [
+              "Microsoft Copilot",
+              "SQL Database",
+              "Artificial Intelligence",
+              "Design AI"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 12,
+          "item": {
+            "@type": "Course",
+            "name": "Cloud Architecture: Core Concepts (2022)",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-14",
+            "about": [
+              "Cloud-Native Architecture",
+              "Instructional Delivery",
+              "Method QAS",
+              "Self Study",
+              "In Accordance"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 13,
+          "item": {
+            "@type": "Course",
+            "name": "Cloud Architecture: Core Concepts",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-14",
+            "timeRequired": "59m",
+            "about": [
+              "Cloud-Native Architecture"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 14,
+          "item": {
+            "@type": "Course",
+            "name": "Building in Microsoft Copilot Studio (July 2024)",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-14",
+            "timeRequired": "1h 3m",
+            "about": [
+              "Microsoft Copilot",
+              "Artificial Intelligence",
+              "Generative AI",
+              "Studio AI"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 15,
+          "item": {
+            "@type": "Course",
+            "name": "Nano Tips for Moving to the Cloud for Business Leaders with Rashim Mogha",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-13",
+            "timeRequired": "7m",
+            "about": [
+              "Digital Transformation",
+              "Cloud Computing"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 16,
+          "item": {
+            "@type": "Course",
+            "name": "Creating Agents and Custom Copilots in SharePoint (No Code Required)",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-13",
+            "timeRequired": "59m",
+            "about": [
+              "Microsoft Copilot",
+              "Artificial Intelligence",
+              "AI Agents"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 17,
+          "item": {
+            "@type": "Course",
+            "name": "Cloud Storage Concepts: Services, Cost Control, and Security",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-13",
+            "timeRequired": "58m",
+            "about": [
+              "Storage Management",
+              "Cloud Storage"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 18,
+          "item": {
+            "@type": "Course",
+            "name": "Building in Microsoft Copilot Studio",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-13",
+            "timeRequired": "1h 1m",
+            "about": [
+              "Microsoft Copilot",
+              "Artificial Intelligence",
+              "Studio AI"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 19,
+          "item": {
+            "@type": "Course",
+            "name": "Microsoft Security Copilot: Prompts and Promptbooks",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-12",
+            "timeRequired": "59m",
+            "about": [
+              "Security Operations",
+              "Artificial Intelligence",
+              "Generative AI"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 20,
+          "item": {
+            "@type": "Course",
+            "name": "Programming Foundations: Software Testing/QA",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-11",
+            "timeRequired": "1h 55m",
+            "about": [
+              "Software Testing",
+              "Programming Foundations",
+              "Software Quality Assurance"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 21,
+          "item": {
+            "@type": "Course",
+            "name": "Microsoft Security Copilot: Working with Preinstalled and Custom Plugins",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-11",
+            "timeRequired": "56m",
+            "about": [
+              "Microsoft Copilot",
+              "Security Operations",
+              "Generative AI"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 22,
+          "item": {
+            "@type": "Course",
+            "name": "Microsoft Security Copilot",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-10",
+            "timeRequired": "40m"
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 23,
+          "item": {
+            "@type": "Course",
+            "name": "Extend Microsoft 365 Copilot with AI Agents",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-10",
+            "timeRequired": "50m",
+            "about": [
+              "Microsoft Copilot",
+              "AI Agents",
+              "Studio"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 24,
+          "item": {
+            "@type": "Course",
+            "name": "Copilot in Teams: AI-Powered Collaboration",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-09",
+            "timeRequired": "21m",
+            "about": [
+              "AI for Business",
+              "Microsoft Copilot",
+              "Microsoft Teams"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 25,
+          "item": {
+            "@type": "Course",
+            "name": "Copilot in PowerPoint: From Prompt to Presentation",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-09",
+            "timeRequired": "45m",
+            "about": [
+              "AI for Business",
+              "Microsoft Copilot",
+              "Artificial Intelligence"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 26,
+          "item": {
+            "@type": "Course",
+            "name": "Copilot dans Word : Créer et améliorer des documents grâce à l'IA",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-08",
+            "timeRequired": "28m",
+            "about": [
+              "Microsoft Copilot",
+              "Artificial Intelligence",
+              "Microsoft Word",
+              "AI"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 27,
+          "item": {
+            "@type": "Course",
+            "name": "Copilot for Microsoft 365: Boosting Productivity in Excel, Word, PowerPoint, Outlook, and Teams",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-07",
+            "timeRequired": "3h 5m",
+            "about": [
+              "Microsoft Copilot",
+              "Artificial Intelligence",
+              "Microsoft Office",
+              "AI"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 28,
+          "item": {
+            "@type": "Course",
+            "name": "Copilot dans Excel : l'analyse de données avec l'IA",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-07",
+            "timeRequired": "43m",
+            "about": [
+              "Data Analysis",
+              "Microsoft Copilot",
+              "Artificial Intelligence",
+              "AI"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 29,
+          "item": {
+            "@type": "Course",
+            "name": "A Beginner's Guide to Writing User Stories",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-04",
+            "timeRequired": "43m",
+            "about": [
+              "User Story",
+              "Development"
+            ]
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 30,
+          "item": {
+            "@type": "Course",
+            "name": "Découvrir Microsoft Copilot Studio",
+            "provider": {
+              "@type": "Organization",
+              "name": "LinkedIn Learning"
+            },
+            "datePublished": "2026-01-03",
+            "timeRequired": "1h 56m",
+            "about": [
+              "Microsoft Copilot",
+              "Artificial Intelligence",
+              "Generative AI",
+              "Studio AI"
+            ]
+          }
+        }
+      ]
     },
     "about": {
       "@type": "Person",
@@ -174,7 +734,7 @@
           <!-- Page Header -->
           <section class="learning-header">
             <h1>LinkedIn Learning Certificates</h1>
-            <p class="learning-subtitle">A curated collection of 409 LinkedIn Learning certificates demonstrating strategic cross-domain learning across 12+ technology domains. This page showcases only LinkedIn Learning achievements—organized by domain, year, and skills.</p>
+            <p class="learning-subtitle">A curated collection of 411 LinkedIn Learning certificates demonstrating strategic cross-domain learning across 12+ technology domains. This page showcases only LinkedIn Learning achievements—organized by domain, year, and skills.</p>
           </section>
 
           <!-- Statistics Dashboard -->
@@ -187,7 +747,7 @@
                 </svg>
               </div>
               <div class="stat-content">
-                <div class="stat-number" id="total-certificates">409</div>
+                <div class="stat-number" id="total-certificates">411</div>
                 <div class="stat-label">LinkedIn Learning Certificates</div>
               </div>
             </div>
@@ -311,7 +871,7 @@
             <main class="learning-main-content">
               <!-- Results Info -->
               <section class="results-info">
-                <p id="results-count">Showing <strong>409</strong> certificates</p>
+                <p id="results-count">Showing <strong>411</strong> certificates</p>
                 <div class="view-toggle">
                   <button id="grid-view" class="view-btn" aria-label="Grid view">⊞ Grid</button>
                   <button id="list-view" class="view-btn active" aria-label="List view">☰ List</button>
@@ -353,7 +913,7 @@
           <!-- Page Header -->
           <section class="learning-header">
             <h1>Certificats LinkedIn Learning</h1>
-            <p class="learning-subtitle">Une collection de 409 certificats LinkedIn Learning démontrant un apprentissage stratégique transdisciplinaire à travers 12+ domaines technologiques. Cette page présente uniquement les réalisations LinkedIn Learning—organisées par domaine, année et compétences.</p>
+            <p class="learning-subtitle">Une collection de 411 certificats LinkedIn Learning démontrant un apprentissage stratégique transdisciplinaire à travers 12+ domaines technologiques. Cette page présente uniquement les réalisations LinkedIn Learning—organisées par domaine, année et compétences.</p>
           </section>
 
           <!-- Statistics Dashboard -->
@@ -366,7 +926,7 @@
                 </svg>
               </div>
               <div class="stat-content">
-                <div class="stat-number" id="total-certificates-fr">409</div>
+                <div class="stat-number" id="total-certificates-fr">411</div>
                 <div class="stat-label">Certificats LinkedIn Learning</div>
               </div>
             </div>
@@ -490,7 +1050,7 @@
             <main class="learning-main-content">
               <!-- Results Info -->
               <section class="results-info">
-                <p id="results-count-fr">Affichage de <strong>409</strong> certificats</p>
+                <p id="results-count-fr">Affichage de <strong>411</strong> certificats</p>
                 <div class="view-toggle">
                   <button id="grid-view-fr" class="view-btn" aria-label="Vue grille">⊞ Grille</button>
                   <button id="list-view-fr" class="view-btn active" aria-label="Vue liste">☰ Liste</button>

--- a/pages/learning.html
+++ b/pages/learning.html
@@ -42,7 +42,8 @@
   
   <link rel="icon" type="image/png" href="../assets/img/favicon.png">
   <link rel="apple-touch-icon" sizes="180x180" href="../assets/img/favicon.png">
-  <meta name="theme-color" content="#0066ff">
+  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#faf9f7">
+  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#121110">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <!-- Pre-paint theme/language restore (must stay inline to avoid flash of wrong theme) -->
   <script>

--- a/pages/learning.html
+++ b/pages/learning.html
@@ -44,7 +44,20 @@
   <link rel="apple-touch-icon" sizes="180x180" href="../assets/img/favicon.png">
   <meta name="theme-color" content="#0066ff">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <!-- Pre-paint theme/language restore (must stay inline to avoid flash of wrong theme) -->
+  <script>
+    (function () {
+      var theme = localStorage.getItem('theme') ||
+        (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', theme);
+      var lang = localStorage.getItem('language') || 'en';
+      document.documentElement.setAttribute('lang', lang);
+      document.documentElement.setAttribute('data-lang', lang);
+      document.documentElement.classList.add('js');
+    })();
+  </script>
   <link rel="stylesheet" href="../assets/css/style.css">
+  <script src="../assets/js/main.js" defer></script>
   <link rel="stylesheet" href="../assets/css/learning.css">
   
   <!-- Breadcrumb Structured Data -->
@@ -87,97 +100,6 @@
   }
   </script>
   
-  <script>
-    function switchLang(lang) {
-      document.querySelectorAll('.lang-content').forEach(el => el.classList.remove('active'));
-      document.querySelectorAll('.lang-toggle button').forEach(btn => btn.classList.remove('active'));
-      const selected = document.getElementById(lang);
-      if (selected) selected.classList.add('active');
-      const btn = document.querySelector(`.lang-toggle button[onclick*="${lang}"]`);
-      if (btn) btn.classList.add('active');
-      
-      document.documentElement.setAttribute('lang', lang);
-      document.documentElement.setAttribute('data-lang', lang);
-      localStorage.setItem('language', lang);
-      
-      // Re-initialize learning page for new language
-      if (window.initLearningPage) {
-        setTimeout(() => {
-          setupEventListeners();
-          if (window.renderSkillsFilter) {
-            renderSkillsFilter(); // Re-render skills filter for new language
-          }
-          const suffix = lang === 'fr' ? '-fr' : '';
-          if (window.filteredCertificates) {
-            renderCertificates(suffix);
-            updateResultsCount(suffix);
-          }
-        }, 100);
-      }
-    }
-    
-    function toggleTheme() {
-      const currentTheme = document.documentElement.getAttribute('data-theme');
-      const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-      
-      document.documentElement.setAttribute('data-theme', newTheme);
-      localStorage.setItem('theme', newTheme);
-      
-      const lightOption = document.getElementById('light-option');
-      const darkOption = document.getElementById('dark-option');
-      
-      if (newTheme === 'light') {
-        lightOption.classList.add('active');
-        darkOption.classList.remove('active');
-      } else {
-        darkOption.classList.add('active');
-        lightOption.classList.remove('active');
-      }
-    }
-    
-    window.onload = function () {
-      const savedLang = localStorage.getItem('language') || 'en';
-      switchLang(savedLang);
-      document.documentElement.setAttribute('lang', savedLang);
-      
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      const savedTheme = localStorage.getItem('theme');
-      const defaultTheme = savedTheme || (prefersDark ? 'dark' : 'light');
-      
-      document.documentElement.setAttribute('data-theme', defaultTheme);
-      
-      const lightOption = document.getElementById('light-option');
-      const darkOption = document.getElementById('dark-option');
-      
-      if (defaultTheme === 'light') {
-        lightOption.classList.add('active');
-        darkOption.classList.remove('active');
-      } else {
-        darkOption.classList.add('active');
-        lightOption.classList.remove('active');
-      }
-      
-      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-        if (!localStorage.getItem('theme')) {
-          const newTheme = e.matches ? 'dark' : 'light';
-          document.documentElement.setAttribute('data-theme', newTheme);
-          
-          if (newTheme === 'light') {
-            lightOption.classList.add('active');
-            darkOption.classList.remove('active');
-          } else {
-            darkOption.classList.add('active');
-            lightOption.classList.remove('active');
-          }
-        }
-      });
-      
-      // Initialize learning page
-      if (window.initLearningPage) {
-        initLearningPage();
-      }
-    };
-  </script>
 </head>
 <body>
   <!-- Skip to main content link for accessibility -->

--- a/pages/learning.html
+++ b/pages/learning.html
@@ -145,16 +145,17 @@
     <!-- Sidebar Navigation -->
     <aside class="sidebar">
       <ul class="sidebar-nav">
-        <li><a href="../index.html#summary">Summary</a></li>
-        <li><a href="../index.html#value-proposition">Value</a></li>
-        <li><a href="../index.html#professional-experience">Experience</a></li>
+        <li><a href="../index.html#hero">Overview</a></li>
+        <li><a href="../index.html#value-proposition">Value Proposition</a></li>
         <li><a href="../index.html#projects">Projects</a></li>
         <li><a href="../index.html#skills">Skills</a></li>
         <li><a href="../index.html#certifications">Certifications</a></li>
         <li><a href="../index.html#continuous-learning">Learning</a></li>
         <li><a href="learning.html" class="active">All Certificates</a></li>
+        <li><a href="../index.html#professional-experience">Experience</a></li>
         <li><a href="../index.html#education">Education</a></li>
         <li><a href="../index.html#faq">FAQ</a></li>
+        <li><a href="../index.html#contact">Contact</a></li>
         <li><a href="about.html">About Me</a></li>
       </ul>
     </aside>
@@ -177,8 +178,8 @@
           </section>
 
           <!-- Statistics Dashboard -->
-          <section class="stats-dashboard">
-            <div class="stat-card-large">
+          <section class="stats-dashboard" data-stagger>
+            <div class="stat-card-large reveal">
               <div class="stat-icon">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M4 19.5C4 18.837 4.263 18.201 4.732 17.732C5.201 17.263 5.837 17 6.5 17H20" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -190,7 +191,7 @@
                 <div class="stat-label">LinkedIn Learning Certificates</div>
               </div>
             </div>
-            <div class="stat-card-large">
+            <div class="stat-card-large reveal">
               <div class="stat-icon">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
@@ -202,7 +203,7 @@
                 <div class="stat-label">Technology Domains</div>
               </div>
             </div>
-            <div class="stat-card-large">
+            <div class="stat-card-large reveal">
               <div class="stat-icon">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <rect x="3" y="4" width="18" height="18" rx="2" stroke="currentColor" stroke-width="2"/>
@@ -214,7 +215,7 @@
                 <div class="stat-label">Active Years</div>
               </div>
             </div>
-            <div class="stat-card-large">
+            <div class="stat-card-large reveal">
               <div class="stat-icon">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
@@ -331,17 +332,17 @@
           <section class="learning-philosophy-section">
             <h2>Learning Philosophy</h2>
             <p>My learning approach is structured around building a comprehensive tech culture that adapts to industry changes. By systematically covering multiple domains—from programming fundamentals to cloud platforms, from DevOps practices to AI tools—I ensure continuous growth and domain-agnostic expertise. This cross-domain learning strategy makes me adaptable to technology shifts and ready for diverse project challenges.</p>
-            <div class="philosophy-points">
-              <div class="philosophy-point">
+            <div class="philosophy-points" data-stagger>
+              <div class="philosophy-point reveal">
                 <strong>Systematic Learning:</strong> Structured approach covering all major technology domains
               </div>
-              <div class="philosophy-point">
+              <div class="philosophy-point reveal">
                 <strong>Domain-Agnostic:</strong> Building expertise that transcends specific technologies
               </div>
-              <div class="philosophy-point">
+              <div class="philosophy-point reveal">
                 <strong>Continuous Growth:</strong> Regular learning to stay current with industry trends
               </div>
-              <div class="philosophy-point">
+              <div class="philosophy-point reveal">
                 <strong>Practical Application:</strong> Learning focused on real-world problem-solving
               </div>
             </div>
@@ -356,8 +357,8 @@
           </section>
 
           <!-- Statistics Dashboard -->
-          <section class="stats-dashboard">
-            <div class="stat-card-large">
+          <section class="stats-dashboard" data-stagger>
+            <div class="stat-card-large reveal">
               <div class="stat-icon">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M4 19.5C4 18.837 4.263 18.201 4.732 17.732C5.201 17.263 5.837 17 6.5 17H20" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -369,7 +370,7 @@
                 <div class="stat-label">Certificats LinkedIn Learning</div>
               </div>
             </div>
-            <div class="stat-card-large">
+            <div class="stat-card-large reveal">
               <div class="stat-icon">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
@@ -381,7 +382,7 @@
                 <div class="stat-label">Domaines Technologiques</div>
               </div>
             </div>
-            <div class="stat-card-large">
+            <div class="stat-card-large reveal">
               <div class="stat-icon">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <rect x="3" y="4" width="18" height="18" rx="2" stroke="currentColor" stroke-width="2"/>
@@ -393,7 +394,7 @@
                 <div class="stat-label">Années Actives</div>
               </div>
             </div>
-            <div class="stat-card-large">
+            <div class="stat-card-large reveal">
               <div class="stat-icon">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
@@ -510,17 +511,17 @@
           <section class="learning-philosophy-section">
             <h2>Philosophie d'Apprentissage</h2>
             <p>Mon approche d'apprentissage est structurée autour de la construction d'une culture tech complète qui s'adapte aux changements de l'industrie. En couvrant systématiquement plusieurs domaines—des fondamentaux de programmation aux plateformes cloud, des pratiques DevOps aux outils IA—je garantis une croissance continue et une expertise indépendante du domaine. Cette stratégie d'apprentissage transdisciplinaire me rend adaptable aux changements technologiques et prêt pour des défis de projets diversifiés.</p>
-            <div class="philosophy-points">
-              <div class="philosophy-point">
+            <div class="philosophy-points" data-stagger>
+              <div class="philosophy-point reveal">
                 <strong>Apprentissage Systématique:</strong> Approche structurée couvrant tous les domaines technologiques majeurs
               </div>
-              <div class="philosophy-point">
+              <div class="philosophy-point reveal">
                 <strong>Indépendant du Domaine:</strong> Construction d'une expertise qui transcende les technologies spécifiques
               </div>
-              <div class="philosophy-point">
+              <div class="philosophy-point reveal">
                 <strong>Croissance Continue:</strong> Apprentissage régulier pour rester à jour avec les tendances de l'industrie
               </div>
-              <div class="philosophy-point">
+              <div class="philosophy-point reveal">
                 <strong>Application Pratique:</strong> Apprentissage axé sur la résolution de problèmes réels
               </div>
             </div>

--- a/profile.json
+++ b/profile.json
@@ -158,6 +158,8 @@
     "learning": {
       "totalCertificates": 411,
       "domains": 11,
+      "status": "ongoing",
+      "currentFocus": ["Agentic AI", "Model Context Protocol (MCP)", "AI Orchestration"],
       "source": "https://brbousnguar.github.io/assets/data/learning-data.json",
       "browser": "https://brbousnguar.github.io/pages/learning.html"
     }

--- a/profile.json
+++ b/profile.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json",
+  "basics": {
+    "name": "Brahim Bousnguar",
+    "label": "Senior E-Commerce Integration Consultant",
+    "email": "b.bousnguar@gmail.com",
+    "url": "https://brbousnguar.github.io/",
+    "image": "https://brbousnguar.github.io/assets/img/profile.jpeg",
+    "summary": "Senior E-Commerce Integration Consultant with 9+ years bridging enterprise e-commerce platforms with modern API-led integration. Deep SAP Commerce Cloud expertise, production-grade MuleSoft Anypoint proficiency, and growing Salesforce ecosystem confidence. Applies AI-augmented development workflows (GitHub Copilot, Ollama, Claude, OpenAI Codex CLI) daily.",
+    "location": {
+      "countryCode": "FR",
+      "region": "France"
+    },
+    "profiles": [
+      {
+        "network": "LinkedIn",
+        "username": "brahim-bousnguar",
+        "url": "https://www.linkedin.com/in/brahim-bousnguar/"
+      },
+      {
+        "network": "GitHub",
+        "username": "brbousnguar",
+        "url": "https://github.com/brbousnguar"
+      }
+    ]
+  },
+  "work": [
+    {
+      "name": "Roche Bobois",
+      "position": "MuleSoft Integration Specialist",
+      "startDate": "2025-01",
+      "summary": "API design and integration using MuleSoft Anypoint Platform for a luxury furniture retailer.",
+      "highlights": [
+        "Designed reusable APIs with Anypoint Studio and Anypoint Code Builder following API-led connectivity principles",
+        "Developed complex DataWeave transformations for data mapping, enrichment, and orchestration",
+        "Built integration flows connecting e-commerce platform with ERP, CRM, and third-party services",
+        "Integrated Salesforce CRM data flows with MuleSoft for end-to-end business process automation",
+        "Established API specifications, best practices, and governance standards for the integration team",
+        "Adopted AI-augmented development: GitHub Copilot, Ollama-based LLM CLI for commit/PR generation, Claude and OpenAI Codex CLI for code review"
+      ]
+    },
+    {
+      "name": "Miele",
+      "position": "Senior SAP Commerce Cloud Consultant",
+      "startDate": "2022-01",
+      "endDate": "2024-12",
+      "summary": "Cloud-native e-commerce platform optimization and microservices architecture.",
+      "highlights": [
+        "Optimized OCC REST APIs for performance and scalability in a global B2C platform",
+        "Designed microservices on SAP BTP Kyma (Kubernetes)",
+        "Led cloud-native migration from on-premise to SAP Commerce Cloud (CCv2) with zero-downtime deployment",
+        "Implemented CI/CD pipelines with Jenkins",
+        "Built integration layers to PIM, OMS, and payment gateways",
+        "Mentored the team on agile practices, microservices patterns, and API design"
+      ]
+    },
+    {
+      "name": "BYK",
+      "position": "Technical Lead — SAP Commerce Cloud",
+      "startDate": "2018-08",
+      "endDate": "2021-12",
+      "summary": "Enterprise B2B multi-country platform migration and integration across 15+ countries.",
+      "highlights": [
+        "Led architecture and migration from SAP Hybris 6.7 to Commerce Cloud CCv2 for a multi-country B2B platform",
+        "Designed integrations with SAP ERP, third-party logistics, and payment providers",
+        "Implemented custom OCC APIs for headless commerce",
+        "Performance optimization and technical SEO for organic traffic growth",
+        "Mentored junior developers on SAP Commerce, Spring, and integration patterns"
+      ]
+    },
+    {
+      "name": "SEB Group",
+      "position": "SAP Hybris Integration Specialist",
+      "startDate": "2016-07",
+      "endDate": "2018-07",
+      "summary": "Multi-brand e-commerce platform integration.",
+      "highlights": [
+        "Integrated international brands (All-Clad, Seb.fr, Krups) into a unified SAP Hybris core platform",
+        "Implemented Vertex tax engine integration for multi-jurisdiction compliance",
+        "Built Salesforce CRM integration with OAuth2 SSO",
+        "Established reusable integration patterns for future brand onboarding"
+      ]
+    }
+  ],
+  "education": [
+    {
+      "institution": "INSEA Rabat",
+      "area": "Computer Science & Business Intelligence",
+      "studyType": "State Engineer",
+      "endDate": "2015"
+    }
+  ],
+  "certificates": [
+    {
+      "name": "SAP Certified Development Professional — SAP Commerce Cloud Developer",
+      "date": "2023",
+      "issuer": "SAP"
+    },
+    {
+      "name": "SAP Certified Associate — SAP Hybris Commerce Business Analyst 6.3",
+      "date": "2018",
+      "issuer": "SAP"
+    }
+  ],
+  "skills": [
+    {
+      "name": "E-Commerce Platforms",
+      "keywords": ["SAP Commerce Cloud (Hybris)", "CCv2", "OCC APIs", "Spartacus", "SAP BTP Kyma"]
+    },
+    {
+      "name": "Integration & APIs",
+      "keywords": ["MuleSoft Anypoint Platform", "Salesforce", "DataWeave", "API-led Connectivity", "RAML", "OAS/Swagger", "REST", "SOAP"]
+    },
+    {
+      "name": "Languages & Frameworks",
+      "keywords": ["Java 17", "Spring Boot", "Spring Security", "Spring Integration", "JavaScript", "Microservices Architecture"]
+    },
+    {
+      "name": "DevOps & Cloud",
+      "keywords": ["Jenkins", "Docker", "Kubernetes", "CI/CD Pipelines", "SAP BTP"]
+    },
+    {
+      "name": "Databases",
+      "keywords": ["MySQL", "SAP HANA", "PostgreSQL"]
+    },
+    {
+      "name": "AI & Dev Tools",
+      "keywords": ["GitHub Copilot", "Ollama (local & cloud LLMs)", "Claude (Anthropic)", "OpenAI Codex CLI"]
+    }
+  ],
+  "languages": [
+    { "language": "English", "fluency": "Professional" },
+    { "language": "French", "fluency": "Professional" }
+  ],
+  "projects": [
+    {
+      "name": "Roche Bobois — API-Led Integration Architecture",
+      "description": "Problem: fragmented point-to-point integrations between e-commerce, ERP, CRM and third-party services. Solution: reusable API-led architecture on MuleSoft Anypoint with governed specifications and DataWeave orchestration. Impact: faster integration delivery and end-to-end business process automation including Salesforce CRM data flows.",
+      "keywords": ["MuleSoft", "API-led", "DataWeave", "Salesforce"],
+      "roles": ["MuleSoft Integration Specialist"]
+    },
+    {
+      "name": "Miele — Cloud-Native Commerce Migration",
+      "description": "Problem: on-premise SAP Hybris limiting scalability of a global B2C platform. Solution: zero-downtime migration to SAP Commerce Cloud (CCv2) plus SAP BTP Kyma microservices and Jenkins CI/CD. Impact: scalable cloud-native platform with optimized OCC APIs.",
+      "keywords": ["SAP Commerce Cloud", "CCv2", "Kyma", "Kubernetes", "CI/CD"],
+      "roles": ["Senior SAP Commerce Cloud Consultant"]
+    },
+    {
+      "name": "BYK — Multi-Country B2B Platform",
+      "description": "Problem: aging SAP Hybris 6.7 B2B platform serving 15+ countries. Solution: led migration to Commerce Cloud CCv2 with custom OCC APIs, ERP/logistics/payment integrations. Impact: modern headless-capable B2B platform with improved performance and organic traffic growth.",
+      "keywords": ["SAP Commerce Cloud", "B2B", "OCC APIs", "SAP ERP"],
+      "roles": ["Technical Lead"]
+    }
+  ],
+  "meta": {
+    "canonical": "https://brbousnguar.github.io/profile.json",
+    "lastModified": "2026-06-11",
+    "learning": {
+      "totalCertificates": 411,
+      "domains": 11,
+      "source": "https://brbousnguar.github.io/assets/data/learning-data.json",
+      "browser": "https://brbousnguar.github.io/pages/learning.html"
+    }
+  }
+}

--- a/robots.txt
+++ b/robots.txt
@@ -11,3 +11,40 @@ Crawl-delay: 1
 Disallow: /*.pdf$
 Disallow: /tools/
 Disallow: /docs/
+
+# --- AI crawlers: explicitly welcome ---
+# Note: a named group overrides the * group entirely for that bot,
+# so these crawlers may also ingest the CV PDF and docs (intentional).
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,19 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://brbousnguar.github.io/</loc>
-    <lastmod>2026-02-22</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://brbousnguar.github.io/pages/about.html</loc>
-    <lastmod>2026-02-22</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://brbousnguar.github.io/pages/learning.html</loc>
-    <lastmod>2026-02-22</lastmod>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>


### PR DESCRIPTION
## Summary

Full modernization of the portfolio for 2026: new warm graphite + amber design system, dynamic hero with proof stats, bento project grid with Problem/Solution/Impact cards, scroll-reveal motion system, and machine-readable profile surfaces for AI agents — all while preserving the bilingual EN/FR DOM architecture and WCAG 2.1 AA contrast.

## Changes

**Foundation**
- Repaired double-encoded UTF-8 in `pages/about.html` / `pages/learning.html` and restored the missing EN language wrapper on the about page (live-site bug)
- Extracted ~250 lines of duplicated inline JS into shared `assets/js/main.js`; added inline pre-paint theme/language snippet to all pages (no more dark-mode flash)
- Dropped unused Poppins font

**Design system**
- Migrated palette from sepia/gold to warm graphite + amber CSS tokens (light + dark), with AA-safe amber rules: `--accent-text` for small text, dark `--accent-contrast` on filled amber surfaces
- Fluid `clamp()` heading scale, radius/transition/glass tokens, `theme-color` meta pair
- Updated `.cursorrules`, `CLAUDE.md`, `.cursor/QUICK_REFERENCE.md` design specs

**Layout & motion**
- New homepage hero (EN+FR): positioning kicker "Senior E-Commerce Integration Consultant · MuleSoft · Applied AI", tagline, dual CTAs, glass portrait card, animated proof-stat counters (9+ yrs / 411+ certs / 15+ countries / 4 clients)
- Bento project grid with Problem/Solution/Impact cards; Roche Bobois as feature card; projects moved up after the value proposition
- Scroll-reveal + stagger system via IntersectionObserver, gated behind `html.js` (content visible without JS) with full `prefers-reduced-motion` override
- Glass top header, value-prop card grid, amber contact CTA band; about/learning pages refreshed to match; sub-page sidebars aligned with the new section order

**Learning narrative (foundation-to-frontier)**
- Homepage section reframed as "Continuous Learning": 2023–2025 cross-domain foundation (411+) plus an amber "2026 focus" callout (agentic AI, MCP, AI orchestration — applied daily in production MuleSoft work), EN + FR
- All certificate counts read "411+" — the Google Drive archive continues past the published dataset (which stops at 2026-01-19)

**AI-agent & SEO readiness**
- New `llms.txt` (llmstxt.org format) and `profile.json` (JSON Resume-style, learning marked ongoing with current agentic-AI focus) + `rel="alternate"` link
- Learning page CollectionPage JSON-LD now embeds the top-30 recent certificates (generated by `assets/js/generate-learning-schema.py`); `numberOfItems` fixed 409 → 411
- Person JSON-LD added to the about page
- `robots.txt`: explicit Allow groups for AI crawlers (GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, Claude-Web, anthropic-ai, PerplexityBot, Perplexity-User, Google-Extended, CCBot, Applebot-Extended)
- `sitemap.xml` lastmod refreshed

## Verification

- EN/FR x light/dark x 1440/768/390 viewports on all 3 pages: no horizontal overflow, zero console errors
- All sidebar anchors resolve in both languages; FOUC check passes with preset dark theme
- Reduced-motion: content immediately visible, counters at final values
- All JSON-LD blocks + `profile.json` parse as valid JSON
- WCAG contrast computed for all amber pairs (all pass AA)

## Screenshots

Before/after screenshots are in the local `.screenshots/` folder (untracked) — drag them into this PR description: `before-home-light.png`, `before-home-dark.png`, `after-home-light.png`, `after-home-dark.png`, `after-home-mobile.png`, `after-home-fr.png`.

## Notes / Follow-ups (tracked in docs/TODO.md)

- **Certificate data refresh (P1):** the Drive archive has Feb–May 2026 certificates not yet in `learning-data.json` — sync PDFs into `archived/2026/`, re-run extract scripts, then `generate-learning-schema.py`
- **robots.txt semantics:** named AI-crawler groups override the `*` group entirely, so those bots may also fetch the CV PDF and `/docs/` — this is intentional (AI ingestion of the CV)
- **OG image:** still the square `profile.jpeg`; a dedicated 1200x630 banner is a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)