### PR TITLE
chore: add .gitignore for local screenshots and automation artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Local screenshots and browser-automation artifacts
+.screenshots/
+.playwright-mcp/
+
+# Local MCP server configuration (may contain machine-specific paths or secrets)
+.mcp.json
+
+# OS cruft
+Thumbs.db
+.DS_Store


### PR DESCRIPTION
## Summary
Adds a `.gitignore` (the repo had none) so local working artifacts never land in commits.

## Changes
- Ignore `.screenshots/` and `.playwright-mcp/` (local browser-verification output — confirmed never tracked on any branch, so no history cleanup needed)
- Ignore `.mcp.json` (machine-local MCP server config)
- Ignore OS cruft (`Thumbs.db`, `.DS_Store`)
